### PR TITLE
Accounted for controller doing vtail mixing

### DIFF
--- a/AttitudeManager.c
+++ b/AttitudeManager.c
@@ -222,7 +222,26 @@ void attitudeManagerRuntime() {
         }
         if ((THROTTLE_CONTROL_SOURCE & controlLevel) == 0)
             sp_ThrottleRate = (icTimeDiff[2]);
-        sp_YawRate = icTimeDiff[3];
+        
+
+        #if(TAIL_TYPE == STANDARD_TAIL)
+        {
+            if ((PITCH_CONTROL_SOURCE & controlLevel) == 0)
+            {
+            sp_PitchRate = icTimeDiff[1];
+            }
+            sp_YawRate = icTimeDiff[3];
+        }
+        #endif
+        #if(TAIL_TYPE == INV_V_TAIL)
+        {
+            if ((PITCH_CONTROL_SOURCE & controlLevel) == 0)
+            {
+                sp_PitchRate = (icTimeDiff[1] - icTimeDiff[3]) / (2 * 0.75);
+            }
+            sp_YawRate = (icTimeDiff[1] + icTimeDiff[3] ) / (2 * 0.75);
+        }
+        #endif
 
         sp_UHFSwitch = icTimeDiff[4];
 //        sp_Type = icTimeDiff[5];


### PR DESCRIPTION
When flying a vtail plane in manual mode, the controller must be
configured to mix the rudder and elevator signals. The added code
accounts for this and properly sets the sp_YawRate and sp_PitchRate.
