### PR TITLE
Altimeter Issue

### DIFF
--- a/InterchipDMA.h
+++ b/InterchipDMA.h
@@ -42,8 +42,8 @@ typedef struct _AMData {
 
 #if PATH_MANAGER
 typedef struct _GPSData {
-    double latitude;  //8 Bytes
-    double longitude; //8 Bytes
+    long double latitude;  //
+    long double longitude; //
     float time;     //4 Bytes
     float speed;
     int altitude;


### PR DESCRIPTION
Once the plane gets to a certain height, the gps and altimeter data gets
corrupted. We've replicated this on the ground by tricking the altimeter
into thinking it's higher (low pressure in a bag). Changing the gps lattitude
and longitude data type to long double appears to fix it. Not sure if
I'm just covering up an issue and not really solving the problem
though....
