### PR TITLE
Added a way to orbit the plane around a specified location

### DIFF
--- a/Autopilot/Path Manager/PathManager.c
+++ b/Autopilot/Path Manager/PathManager.c
@@ -340,7 +340,23 @@ char followWaypoints(PathData* currentWaypoint, float* position, float heading, 
 
             *sp_Heading = (int)followStraightPath((float*)&waypointDirection, (float*)targetCoordinates, (float*)position, heading);
         }
-        else{
+        else{            
+            
+            // if target waypoint is a hold waypoint the plane will follow the orbit until the waypoint is updated or removed
+            if (targetWaypoint->type == HOLD_WAYPOINT) {
+                char turnDirection = waypointDirection[0] * nextWaypointDirection[1] - waypointDirection[1] * nextWaypointDirection[0]>0?1:-1;
+                float euclideanWaypointDirection = sqrt(pow(nextWaypointDirection[0] - waypointDirection[0],2) + pow(nextWaypointDirection[1] - waypointDirection[1],2) + pow(nextWaypointDirection[2] - waypointDirection[2],2)) * ((nextWaypointDirection[0] - waypointDirection[0]) < 0?-1:1) * ((nextWaypointDirection[1] - waypointDirection[1]) < 0?-1:1) * ((nextWaypointDirection[2] - waypointDirection[2]) < 0?-1:1);
+                
+                float turnCenter[3];
+                turnCenter[0] = targetCoordinates[0] + (targetWaypoint->radius/tan(turningAngle/2) * (nextWaypointDirection[0] - waypointDirection[0])/euclideanWaypointDirection);
+                turnCenter[1] = targetCoordinates[1] + (targetWaypoint->radius/tan(turningAngle/2) * (nextWaypointDirection[1] - waypointDirection[1])/euclideanWaypointDirection);
+                turnCenter[2] = targetCoordinates[2] + (targetWaypoint->radius/tan(turningAngle/2) * (nextWaypointDirection[2] - waypointDirection[2])/euclideanWaypointDirection);
+                
+                *sp_Heading = (int)followOrbit((float*) &turnCenter,targetWaypoint->radius, turnDirection, (float*)position, heading);
+                
+                return currentWaypoint->index;
+            }
+            
             float halfPlane[3];
             halfPlane[0] = targetCoordinates[0] + (targetWaypoint->radius/tan(turningAngle/2)) * nextWaypointDirection[0];
             halfPlane[1] = targetCoordinates[1] + (targetWaypoint->radius/tan(turningAngle/2)) * nextWaypointDirection[1];

--- a/Autopilot/Path Manager/PathManager.h
+++ b/Autopilot/Path Manager/PathManager.h
@@ -28,6 +28,7 @@
 //Waypoint types
 #define DEFAULT_WAYPOINT 0
 #define PROBE_DROP_WAYPOINT 1
+#define HOLD_WAYPOINT 2
 
 //Structs and typedefs
 


### PR DESCRIPTION
The added lines are the exact same logic as used elsewhere in the code
(copy and pasted into the if statement to keep the order of calculations
the same as before outside the if statement). The followOrbit function
is called here as it simply causes the plane to follow an orbit
independant of an entrance and exit point. To cause the plane to exit
the loop the target waypoint would have to be updated or destroyed. The
size of the orbit can be chaged using the waypoint radius value.