### PR TITLE
InputCompare module refactor, documentation, and bug fixes

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.h
+++ b/Autopilot/AttitudeManager/AttitudeManager.h
@@ -83,8 +83,11 @@
 #define IMU_PITCH_RATE   1
 #define IMU_ROLL_RATE    0
 
-
-//channels
+/**
+ * RC receiver channel configuration. Note that
+ * Note that only channel 8 will work hardware-wise as the
+ * autopilot channel, as it directly controls the relays
+ */
 #define THROTTLE_IN_CHANNEL 1
 #define THROTTLE_OUT_CHANNEL 1
 #define ROLL_IN_CHANNEL 2
@@ -96,7 +99,7 @@
 #define FLAP_IN_CHANNEL 5
 #define FLAP_OUT_CHANNEL 5
 #define UHF_STATUS_IN_CHANNEL 7
-#define PROBE1_OUT_CHANNEL 6
+#define PROBE1_OUT_CHANNEL 6 //TODO: Remove the probe drop channels as they are no longer used
 #define PROBE2_OUT_CHANNEL 7
 #define PROBE3_OUT_CHANNEL 8
 #define AUTOPILOT_ACTIVE_IN_CHANNEL 8 //Do not change this value, as only 8 will work hardware-wise

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -9,18 +9,18 @@
 #include "timer.h"
 
 /**
- * Raw captures of timer1 and timer2 for all 8 channels
+ * Holds the capture start and end time so that we can compare them later
  */
 static unsigned int start_time[8];
 static unsigned int end_time[8];
 
 /**
- * Interrupt flag for if new data is available
+ * Interrupt flag for if new data is available and ready to read
  */
 static char new_data_available[8];
 
 /**
- * The actual time between interrupts (or pulses, in ms)
+ * The actual time between interrupts (in timer2 ticks, not ms)
  */
 static unsigned int capture_value[8];
 
@@ -32,6 +32,7 @@ void initIC(char initIC)
     initInputCapture(initIC);
     initTimer2();
 }
+
 unsigned int* getICValues()
 {
     //Calculate and Update the Input Values
@@ -58,8 +59,8 @@ static void calculateICValue(unsigned char channel)
             /*
              * We've reached roll over. Add the maximum time (PR2) to the original start time,
              * and add on the end time to find the total time. Note that the PR2 register stores
-             * the time period for Timer2, and is set at 20ms (in initialization function). 
-             * Since an average PWM width is 2-3ms max, this is more than sufficient.
+             * the time period for Timer2, and is set at 20ms. After 20ms, the timer will
+             * reset. Since an average PWM width is 2-3ms max, this is more than sufficient.
              */
             capture_value[channel] = ((PR2 - start_time[channel]) + end_time[channel]);
         }

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -11,8 +11,8 @@
 /**
  * Raw captures of timer1 and timer2 for all 8 channels
  */
-static int start_time[8];
-static int end_time[8];
+static unsigned int start_time[8];
+static unsigned int end_time[8];
 
 /**
  * Interrupt flag for if new data is available
@@ -53,7 +53,7 @@ static void calculateICValue(unsigned char channel)
     if (new_data_available[channel] == 1) {
         //If the second time is greater than the first time then we have not met roll over
         if (end_time[channel] > start_time[channel]) {
-            capture_value[channel] = (end_time[channel] - start_time[channel]);
+            capture_value[channel] = end_time[channel] - start_time[channel];
         } else {
             /*
              * We've reached roll over. Add the maximum time (PR2) to the original start time,

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -79,8 +79,12 @@ static void initInputCapture(char initIC)
     if (initIC & 0b01) {
         IC1CONbits.ICM = 0b00; // Disable Input Capture 1 module (required to change it)
         IC1CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC1CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC1CONbits.ICM = 0b001; // Generate capture event on every Rising and Falling edge
+        
+        /**
+         * Generate capture event on every Rising and Falling edge
+         * Note that the ICI register is ignored when ICM is in edge detection mode (001)
+         */
+        IC1CONbits.ICM = 0b001; 
 
         // Enable Capture Interrupt And Timer2
         IPC0bits.IC1IP = 7; // Setup IC1 interrupt priority level - Highest
@@ -90,7 +94,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b10) {
         IC2CONbits.ICM = 0b00;
         IC2CONbits.ICTMR = 1;
-        IC2CONbits.ICI = 0b11;
         IC2CONbits.ICM = 0b001;
 
         IPC1bits.IC2IP = 7;
@@ -100,7 +103,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b100) {
         IC3CONbits.ICM = 0b00;
         IC3CONbits.ICTMR = 1;
-        IC3CONbits.ICI = 0b11;
         IC3CONbits.ICM = 0b001;
 
         IPC9bits.IC3IP = 7;
@@ -110,7 +112,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b1000) {
         IC4CONbits.ICM = 0b00;
         IC4CONbits.ICTMR = 1;
-        IC4CONbits.ICI = 0b11;
         IC4CONbits.ICM = 0b001;
 
         IPC9bits.IC4IP = 7;
@@ -120,7 +121,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b10000) {
         IC5CONbits.ICM = 0b00;
         IC5CONbits.ICTMR = 1;
-        IC5CONbits.ICI = 0b11;
         IC5CONbits.ICM = 0b001;
 
         IPC9bits.IC5IP = 7;
@@ -130,7 +130,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b100000) {
         IC6CONbits.ICM = 0b00;
         IC6CONbits.ICTMR = 1;
-        IC6CONbits.ICI = 0b11;
         IC6CONbits.ICM = 0b001;
 
         IPC10bits.IC6IP = 7;
@@ -140,7 +139,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b1000000) {
         IC7CONbits.ICM = 0b00;
         IC7CONbits.ICTMR = 1;
-        IC7CONbits.ICI = 0b11;
         IC7CONbits.ICM = 0b001;
 
         IPC5bits.IC7IP = 7;
@@ -150,7 +148,6 @@ static void initInputCapture(char initIC)
     if (initIC & 0b10000000) {
         IC8CONbits.ICM = 0b00;
         IC8CONbits.ICTMR = 1;
-        IC8CONbits.ICI = 0b11;
         IC8CONbits.ICM = 0b001;
 
         IPC5bits.IC8IP = 7;

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -177,6 +177,17 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC1Interrupt(void)
         end_time[0] = IC1BUF;
         new_data_available[0] = 1;
     }
+    
+    /**
+     * Clear the input compare buffer to avoid any issues when hot swapping PWM cables.
+     * Without this, when hot-swapping PWM connections, you may get weird values (in the 10000's range)
+     * when reading off of the connection. Note that in normal circumstances, the maximum size
+     * of the buffer at any time will be 1, so this while loop should never execute. Its only when
+     * you disconnect it and reconnect it that stuff gets weird.
+     */
+    while (IC1CONbits.ICBNE) { //while the ic buffer not empty flag is set
+        IC1BUF; //read a value from the 4-size FIFO buffer
+    }
     IFS0bits.IC1IF = 0; //reset the interrupt flag
 }
 
@@ -190,6 +201,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC2Interrupt(void)
     } else {
         end_time[1] = IC2BUF;
         new_data_available[1] = 1;
+    }
+    
+    while (IC2CONbits.ICBNE) {
+        IC2BUF;
     }
     IFS0bits.IC2IF = 0;
 }
@@ -205,6 +220,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC3Interrupt(void)
         end_time[2] = IC3BUF;
         new_data_available[2] = 1;
     }
+    
+    while (IC3CONbits.ICBNE) {
+        IC3BUF;
+    }
     IFS2bits.IC3IF = 0;
 }
 
@@ -218,6 +237,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC4Interrupt(void)
     } else {
         end_time[3] = IC4BUF;
         new_data_available[3] = 1;
+    }
+    
+    while (IC4CONbits.ICBNE) {
+        IC4BUF;
     }
     IFS2bits.IC4IF = 0;
 }
@@ -233,6 +256,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC5Interrupt(void)
         end_time[4] = IC5BUF;
         new_data_available[4] = 1;
     }
+    
+    while (IC5CONbits.ICBNE) {
+        IC5BUF;
+    }
     IFS2bits.IC5IF = 0;
 }
 
@@ -246,6 +273,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC6Interrupt(void)
     } else {
         end_time[5] = IC6BUF;
         new_data_available[5] = 1;
+    }
+    
+    while (IC6CONbits.ICBNE) {
+        IC6BUF;
     }
     IFS2bits.IC6IF = 0;
 }
@@ -261,6 +292,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC7Interrupt(void)
         end_time[6] = IC7BUF;
         new_data_available[6] = 1;
     }
+
+    while (IC7CONbits.ICBNE) {
+        IC7BUF;
+    }
     IFS1bits.IC7IF = 0;
 }
 
@@ -274,6 +309,10 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC8Interrupt(void)
     } else {
         end_time[7] = IC8BUF;
         new_data_available[7] = 1;
+    }
+
+    while (IC8CONbits.ICBNE) {
+        IC8BUF;
     }
     IFS1bits.IC8IF = 0;
 }

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -1,153 +1,83 @@
 /*
- * File:   InputCapture.c
- *
- * Created on February 9, 2010, 10:53 AM
+ * @file InputCapture.c
+ * @created February 9, 2010, 10:53 AM
  */
 
-// include files
-#include <stdio.h>
-#include <stdlib.h>
 #include <p33Fxxxx.h>
 #include "InputCapture.h"
 #include "OutputCompare.h"
+#include "timer.h"
 
+/**
+ * Raw captures of timer1 and timer2 for all 8 channels
+ */
+static int start_time[8];
+static int end_time[8];
 
-//Global variables: each variable is stored in an array to hold all the input
-//                  channel values (from IC1 - IC8)
+/**
+ * Interrupt flag for if new data is available
+ */
+static char new_data_available[8];
 
+/**
+ * The actual time between interrupts (or pulses, in ms)
+ */
+static unsigned int capture_value[8];
 
-int t1[8];            // Time 1 and Time 2 capture for
-int t2[8];            // each input channel
+static void initInputCapture(char initIC);
+static void calculateICValue(unsigned char channel);
 
-short icInterruptFlag[8];     // Flag bit
-unsigned int icTime[8];       // Time between interrupts (time between each pulse)
-
-// Time calculation stored in an array
-void initTimer2(void)    // Initialize and enable Timer2
+void initIC(char initIC)
 {
-    T2CONbits.TON = 0; // Disable Timer
-    T2CONbits.TCS = 0; // Select internal instruction cycle clock
-    T2CONbits.TGATE = 0; // Disable Gated Timer mode
-    TMR2 = 0x00; // Clear timer register
-    setPeriod(20);
-    //PR2 = MSEC * 20; // Load the period value = 20ms                        //
-    IPC1bits.T2IP = 0x01; // Set Timer 2 Interrupt Priority Level - Lowest
-    IFS0bits.T2IF = 0; // Clear Timer 2 Interrupt Flag
-    IEC0bits.T2IE = 0; // Disable Timer 2 interrupt
-    T2CONbits.TON = 1; // Start Timer
+    initInputCapture(initIC);
+    initTimer2();
 }
-
-
-
-//Input Capture #1 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC1Interrupt(void)
+unsigned int* getICValues()
 {
-    if (PORTDbits.RD8 == 1)    // if IC signal is goes 0 --> 1, set t1 equal to
-        t1[0]=IC1BUF;          // buffer value or else if signal goes 1 --> 0
-    else                       // set t2 to buffer
-    {
-        t2[0]=IC1BUF;
-        icInterruptFlag[0] = 1;
+    //Calculate and Update the Input Values
+    char channel;
+    for (channel = 0; channel < 8; channel++) {
+        calculateICValue(channel);
     }
-    IFS0bits.IC1IF=0;
+    return capture_value;
 }
 
-//Input Capture #2 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC2Interrupt(void)
+unsigned int getICValue(unsigned char channel)
 {
-    if (PORTDbits.RD9 == 1)
-        t1[1]=IC2BUF;
-    else
-    {
-        t2[1]=IC2BUF;
-        icInterruptFlag[1] = 1;
-    }
-    IFS0bits.IC2IF=0;
+    calculateICValue(channel);
+    return capture_value[channel];
 }
 
-//Input Capture #3 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC3Interrupt(void)
+static void calculateICValue(unsigned char channel)
 {
-    if (PORTDbits.RD10 == 1)
-        t1[2]=IC3BUF;
-    else
-    {
-        t2[2]=IC3BUF;
-        icInterruptFlag[2] = 1;
+    if (new_data_available[channel] == 1) {
+        //If the second time is greater than the first time then we have not met roll over
+        if (end_time[channel] > start_time[channel]) {
+            capture_value[channel] = (end_time[channel] - start_time[channel]);
+        } else {
+            /*
+             * We've reached roll over. Add the maximum time (PR2) to the original start time,
+             * and add on the end time to find the total time. Note that the PR2 register stores
+             * the time period for Timer2, and is set at 20ms (in initialization function). 
+             * Since an average PWM width is 2-3ms max, this is more than sufficient.
+             */
+            capture_value[channel] = ((PR2 - start_time[channel]) + end_time[channel]);
+        }
+
+        new_data_available[channel] = 0;
     }
-    IFS2bits.IC3IF=0;
 }
 
-//Input Capture #4 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC4Interrupt(void)
+/**
+ * Initializes interrupts for the specified channels. Sets Timer2
+ * as the time base, and configures it so that interrupts occur on every rising and
+ * falling edge
+ * @param initIC An 8-bit bit mask specifying which channels to enable interrupts on
+ */
+static void initInputCapture(char initIC)
 {
-    if (PORTDbits.RD11 == 1)
-        t1[3]=IC4BUF;
-    else
-    {
-        t2[3]=IC4BUF;
-        icInterruptFlag[3] = 1;
-    }
-    IFS2bits.IC4IF=0;
-}
-
-//Input Capture #5 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC5Interrupt(void)
-{
-    if (PORTDbits.RD12 == 1)
-        t1[4]=IC5BUF;
-    else
-    {
-        t2[4]=IC5BUF;
-        icInterruptFlag[4] = 1;
-    }
-    IFS2bits.IC5IF=0;
-}
-
-//Input Capture #6 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC6Interrupt(void)
-{
-    if (PORTDbits.RD13 == 1)
-        t1[5]=IC6BUF;
-    else
-    {
-        t2[5]=IC6BUF;
-        icInterruptFlag[5] = 1;
-    }
-    IFS2bits.IC6IF=0;
-}
-
-//Input Capture #7 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC7Interrupt(void)
-{
-    if (PORTDbits.RD14 == 1)
-        t1[6]=IC7BUF;
-    else
-    {
-        t2[6]=IC7BUF;
-        icInterruptFlag[6] = 1;
-    }
-    IFS1bits.IC7IF=0;
-}
-
-//Input Capture #8 Interrupt Function
-void __attribute__((__interrupt__,no_auto_psv)) _IC8Interrupt(void)
-{
-    if (PORTDbits.RD15 == 1)
-        t1[7]=IC8BUF;
-    else
-    {
-        t2[7]=IC8BUF;
-        icInterruptFlag[7] = 1;
-    }
-    IFS1bits.IC8IF=0;
-}
-
-
-void initInputCapture(char initIC)     // Capture Interrupt Service Routine
-{                           //    unsigned int timePeriod= 0;
-    if (initIC & 0b01){
-        IC1CONbits.ICM = 0b00; // Disable Input Capture 1 module
+    if (initIC & 0b01) {
+        IC1CONbits.ICM = 0b00; // Disable Input Capture 1 module (required to change it)
         IC1CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
         IC1CONbits.ICI = 0b11; // Interrupt on every capture event
         IC1CONbits.ICM = 0b001; // Generate capture event on every Rising and Falling edge
@@ -157,142 +87,196 @@ void initInputCapture(char initIC)     // Capture Interrupt Service Routine
         IFS0bits.IC1IF = 0; // Clear IC1 Interrupt Status Flag
         IEC0bits.IC1IE = 1; // Enable IC1 interrupt
     }
-    if (initIC & 0b10){
-        IC2CONbits.ICM = 0b00; // Disable Input Capture 2 module
-        IC2CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC2CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC2CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b10) {
+        IC2CONbits.ICM = 0b00;
+        IC2CONbits.ICTMR = 1;
+        IC2CONbits.ICI = 0b11;
+        IC2CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC1bits.IC2IP = 7; // Setup IC2 interrupt priority level - Highest
-        IFS0bits.IC2IF = 0; // Clear IC2 Interrupt Status Flag
-        IEC0bits.IC2IE = 1; // Enable IC2 interrupt
+        IPC1bits.IC2IP = 7;
+        IFS0bits.IC2IF = 0;
+        IEC0bits.IC2IE = 1;
     }
-    if (initIC & 0b100){
-        IC3CONbits.ICM = 0b00; // Disable Input Capture 3 module
-        IC3CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC3CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC3CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b100) {
+        IC3CONbits.ICM = 0b00;
+        IC3CONbits.ICTMR = 1;
+        IC3CONbits.ICI = 0b11;
+        IC3CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC9bits.IC3IP = 7; // Setup IC3 interrupt priority level - Highest
-        IFS2bits.IC3IF = 0; // Clear IC3 Interrupt Status Flag
-        IEC2bits.IC3IE = 1; // Enable IC3 interrupt
+        IPC9bits.IC3IP = 7;
+        IFS2bits.IC3IF = 0;
+        IEC2bits.IC3IE = 1;
     }
-    if (initIC & 0b1000){
-        IC4CONbits.ICM = 0b00; // Disable Input Capture 4 module
-        IC4CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC4CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC4CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b1000) {
+        IC4CONbits.ICM = 0b00;
+        IC4CONbits.ICTMR = 1;
+        IC4CONbits.ICI = 0b11;
+        IC4CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC9bits.IC4IP = 7; // Setup IC4 interrupt priority level - Highest
-        IFS2bits.IC4IF = 0; // Clear IC4 Interrupt Status Flag
-        IEC2bits.IC4IE = 1; // Enable IC4 interrupt
+        IPC9bits.IC4IP = 7;
+        IFS2bits.IC4IF = 0;
+        IEC2bits.IC4IE = 1;
     }
-    if (initIC & 0b10000){
-        IC5CONbits.ICM = 0b00; // Disable Input Capture 5 module
-        IC5CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC5CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC5CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b10000) {
+        IC5CONbits.ICM = 0b00;
+        IC5CONbits.ICTMR = 1;
+        IC5CONbits.ICI = 0b11;
+        IC5CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC9bits.IC5IP = 7; // Setup IC5 interrupt priority level - Highest
-        IFS2bits.IC5IF = 0; // Clear IC5 Interrupt Status Flag
-        IEC2bits.IC5IE = 1; // Enable IC5 interrupt
+        IPC9bits.IC5IP = 7;
+        IFS2bits.IC5IF = 0;
+        IEC2bits.IC5IE = 1;
     }
-    if (initIC & 0b100000){
-        IC6CONbits.ICM = 0b00; // Disable Input Capture 6 module
-        IC6CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC6CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC6CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b100000) {
+        IC6CONbits.ICM = 0b00;
+        IC6CONbits.ICTMR = 1;
+        IC6CONbits.ICI = 0b11;
+        IC6CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC10bits.IC6IP = 7; // Setup IC6 interrupt priority level - Highest
-        IFS2bits.IC6IF = 0; // Clear IC6 Interrupt Status Flag
-        IEC2bits.IC6IE = 1; // Enable IC6 interrupt
+        IPC10bits.IC6IP = 7;
+        IFS2bits.IC6IF = 0;
+        IEC2bits.IC6IE = 1;
     }
-    if (initIC & 0b1000000){
-        IC7CONbits.ICM = 0b00; // Disable Input Capture 7 module
-        IC7CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC7CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC7CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b1000000) {
+        IC7CONbits.ICM = 0b00;
+        IC7CONbits.ICTMR = 1;
+        IC7CONbits.ICI = 0b11;
+        IC7CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC5bits.IC7IP = 7; // Setup IC7 interrupt priority level - Highest
-        IFS1bits.IC7IF = 0; // Clear IC7 Interrupt Status Flag
-        IEC1bits.IC7IE = 1; // Enable IC7 interrupt
+        IPC5bits.IC7IP = 7;
+        IFS1bits.IC7IF = 0;
+        IEC1bits.IC7IE = 1;
     }
-    if (initIC & 0b10000000){
-        IC8CONbits.ICM = 0b00; // Disable Input Capture 8 module
-        IC8CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        IC8CONbits.ICI = 0b11; // Interrupt on every capture event
-        IC8CONbits.ICM = 0b001; // Generate capture event on every Rising edge
+    if (initIC & 0b10000000) {
+        IC8CONbits.ICM = 0b00;
+        IC8CONbits.ICTMR = 1;
+        IC8CONbits.ICI = 0b11;
+        IC8CONbits.ICM = 0b001;
 
-        // Enable Capture Interrupt And Timer2
-        IPC5bits.IC8IP = 7; // Setup IC8 interrupt priority level - Highest
-        IFS1bits.IC8IF = 0; // Clear IC8 Interrupt Status Flag
-        IEC1bits.IC8IE = 1; // Enable IC8 interrupt
+        IPC5bits.IC8IP = 7;
+        IFS1bits.IC8IF = 0;
+        IEC1bits.IC8IE = 1;
     }
-
 }
 
-// initialize function
-void initIC(char initIC)
+/**
+ * Below are the configured interrupt handler functions for when there is an edge
+ * change on an enabled PWM channel. These functions will mark the new_data_available
+ * bits, as well as set/save the appropriate timer values.
+ * 
+ * If a high value is detected on an interrupt, it means we went from 0->1, so we mark
+ * the start time. Otherwise, we mark the end time. In the latter case, we'll also mark
+ * the data available bit as either 1 or 0. If we went from 0->1, we'll mark the data as not
+ * ready. If it went from 0->1, we'll mark it as ready.
+ */
+//Input Capture #1 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC1Interrupt(void)
 {
-    initInputCapture(initIC);
-    initTimer2();
-}
-
-unsigned int* getICValues(){
-            //Calculate and Update the Input Values
-
-        short ic;
-        for (ic = 0; ic < 8; ic++)
-        {
-            //If new data has been received on the given channel
-            if (icInterruptFlag[ic] == 1)
-            {
-              //If the second time is greater than the first time then we have not met roll over
-              if(t2[ic] > t1[ic])
-              {
-                 icTime[ic] = (t2[ic] - t1[ic]);
-                 icInterruptFlag[ic] = 0;
-              }
-              //Roll over has been made, therefore do math to find the time difference
-              //(Max time - t1) is the upper difference
-              //Adding the second time (time from 0) gives you the total time difference
-              else
-              {
-                 icTime[ic] = ((PR2 - t1[ic]) + t2[ic]);
-                 icInterruptFlag[ic] = 0;
-
-              }
-            }
-        }
-        return icTime;
-}
-
-unsigned int getICValue(unsigned char channel){
-    unsigned int ic = (unsigned int)channel;
-    //If new data has been received on the given channel
-    if (icInterruptFlag[ic] == 1)
-    {
-      //If the second time is greater than the first time then we have not met roll over
-      if(t2[ic] > t1[ic])
-      {
-         icTime[ic] = (t2[ic] - t1[ic]);
-         icInterruptFlag[ic] = 0;
-      }
-      //Roll over has been made, therefore do math to find the time difference
-      //(Max time - t1) is the upper difference
-      //Adding the second time (time from 0) gives you the total time difference
-      else
-      {
-         icTime[ic] = ((PR2 - t1[ic]) + t2[ic]);
-         icInterruptFlag[ic] = 0;
-
-      }
+    if (PORTDbits.RD8 == 1) { // if IC signal is goes 0 --> 1
+        start_time[0] = IC1BUF;
+        new_data_available[0] = 0; //we should do this so that we don't parse partial values (with wrong start time)
+    } else {
+        end_time[0] = IC1BUF;
+        new_data_available[0] = 1;
     }
-    return icTime[ic];
+    IFS0bits.IC1IF = 0; //reset the interrupt flag
+}
+
+//Input Capture #2 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC2Interrupt(void)
+{
+    if (PORTDbits.RD9 == 1) {
+        start_time[1] = IC2BUF;
+        new_data_available[1] = 0;
+    } else {
+        end_time[1] = IC2BUF;
+        new_data_available[1] = 1;
+    }
+    IFS0bits.IC2IF = 0;
+}
+
+//Input Capture #3 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC3Interrupt(void)
+{
+    if (PORTDbits.RD10 == 1) {
+        start_time[2] = IC3BUF;
+        new_data_available[2] = 0;
+    } else {
+        end_time[2] = IC3BUF;
+        new_data_available[2] = 1;
+    }
+    IFS2bits.IC3IF = 0;
+}
+
+//Input Capture #4 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC4Interrupt(void)
+{
+    if (PORTDbits.RD11 == 1) {
+        start_time[3] = IC4BUF;
+        new_data_available[3] = 0;
+    } else {
+        end_time[3] = IC4BUF;
+        new_data_available[3] = 1;
+    }
+    IFS2bits.IC4IF = 0;
+}
+
+//Input Capture #5 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC5Interrupt(void)
+{
+    if (PORTDbits.RD12 == 1) {
+        start_time[4] = IC5BUF;
+        new_data_available[4] = 0;
+    } else {
+        end_time[4] = IC5BUF;
+        new_data_available[4] = 1;
+    }
+    IFS2bits.IC5IF = 0;
+}
+
+//Input Capture #6 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC6Interrupt(void)
+{
+    if (PORTDbits.RD13 == 1) {
+        start_time[5] = IC6BUF;
+        new_data_available[5] = 0;
+    } else {
+        end_time[5] = IC6BUF;
+        new_data_available[5] = 1;
+    }
+    IFS2bits.IC6IF = 0;
+}
+
+//Input Capture #7 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC7Interrupt(void)
+{
+    if (PORTDbits.RD14 == 1) {
+        start_time[6] = IC7BUF;
+        new_data_available[6] = 0;
+    } else {
+        end_time[6] = IC7BUF;
+        new_data_available[6] = 1;
+    }
+    IFS1bits.IC7IF = 0;
+}
+
+//Input Capture #8 Interrupt Function
+
+void __attribute__((__interrupt__, no_auto_psv)) _IC8Interrupt(void)
+{
+    if (PORTDbits.RD15 == 1) {
+        start_time[7] = IC8BUF;
+        new_data_available[7] = 0;
+    } else {
+        end_time[7] = IC8BUF;
+        new_data_available[7] = 1;
+    }
+    IFS1bits.IC8IF = 0;
 }

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -1,29 +1,34 @@
 /*
- * File:   InputCapture.h
- * Author: Chris Hajduk
- *
- * Created on March 4, 2013, 10:31 PM
+ * @file InputCapture.h
+ * @author Chris Hajduk
+ * @created March 4, 2013, 10:31 PM
+ * @description This file provides the methods necessary to access the input capture
+ * capabilities of the chip. In essence, it lets you get the PWM values from the 8
+ * PWM capable channels that the chip has.
  */
 
 #ifndef INPUTCAPTURE_H
 #define	INPUTCAPTURE_H
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
-// Includes
 #include "main.h"
-//TODO: Finish these function prototype descriptions
-//Function Prototypes
-void initInputCapture(char initIC);
+
+/**
+ * Initializes capture configuration of the PWM input channels.
+ * @param initIC An 8-bit bitmask specifying which channels to enable (will enable interrupts on these)
+ */
 void initIC(char initIC);
-void initTimer2();
+
+/**
+ * Gets the input capture value (aka PWM) of all the channels
+ * @return Array containing all the channel values
+ */
 unsigned int* getICValues();
+
+/**
+ * Gets the input capture value of a specific value
+ * @param channel number from 0-7
+ * @return PWM value of the channel in ms
+ */
 unsigned int getICValue(unsigned char channel);
 
-#ifdef	__cplusplus
-}
 #endif
-
-#endif	/* INPUTCAPTURE_H */

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -3,8 +3,8 @@
  * @author Chris Hajduk
  * @created March 4, 2013, 10:31 PM
  * @description This file provides the methods necessary to access the input capture
- * capabilities of the chip. In essence, it lets you get the PWM values from the 8
- * PWM capable channels that the chip has.
+ * capabilities of the chip. In essence, it lets you get the raw, uncalibrated PWM values 
+ * from the 8 available input compare channels
  */
 
 #ifndef INPUTCAPTURE_H

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -19,7 +19,7 @@
 void initIC(char initIC);
 
 /**
- * Gets the input capture value (aka PWM) of all the channels
+ * Gets the input capture value (in ticks) of all the channels
  * @return Array containing all the channel values
  */
 unsigned int* getICValues();
@@ -27,7 +27,8 @@ unsigned int* getICValues();
 /**
  * Gets the input capture value of a specific value
  * @param channel number from 0-7
- * @return PWM value of the channel in ms
+ * @return Value of the IC channel. This is in Timer2 ticks, not ms! 
+ * The timer module defines number of ticks in a ms
  */
 unsigned int getICValue(unsigned char channel);
 

--- a/Autopilot/AttitudeManager/OutputCompare.c
+++ b/Autopilot/AttitudeManager/OutputCompare.c
@@ -4,8 +4,6 @@
  * Created on February 9, 2010, 10:53 AM
  */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <p33Fxxxx.h>
 #include "OutputCompare.h"
 #include "InputCapture.h"
@@ -95,6 +93,10 @@ OC8CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
 OC8CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
 }
 
+/**
+ * Set the period value of Timer2
+ * @param time Time in ms
+ */
 void setPeriod(double time) 
 {
          T2CONbits.TCKPS = 0x02; //1:64 scaler

--- a/Autopilot/AttitudeManager/timer.c
+++ b/Autopilot/AttitudeManager/timer.c
@@ -8,17 +8,27 @@
 #include "main.h"
 #include "timer.h"
 
-long int time = 0;
+static long int time = 0;
 
-//NEED A BETTER TIMER - THIS IS TOO SLOW. TIMER3?? Something accurate to 1ms.
+/**
+ * Initializes Timer2. Its used as a 16-bit timer
+ */
+void initTimer2(void)
+{
+    T2CONbits.TON = 0; // Disable Timer
+    T2CONbits.TCS = 0; // Select internal instruction cycle clock
+    T2CONbits.TGATE = 0; // Disable Gated Timer mode
+    TMR2 = 0x00; // Clear timer register
+    setPeriod(20); // Load the period value = 20ms. Required for proper output compare                
+    IPC1bits.T2IP = 0x01; // Set Timer 2 Interrupt Priority Level - Lowest
+    IFS0bits.T2IF = 0; // Clear Timer 2 Interrupt Flag
+    IEC0bits.T2IE = 0; // Disable Timer 2 interrupt
+    T2CONbits.TON = 1; // Start Timer
+}
 
-//void __attribute__((__interrupt__, no_auto_psv)) _T2Interrupt(void){
-//    //TODO: Disable this interrupt
-//    //Timer Interrupt used for the control loops and data link which is accurate to 20ms
-////    time += 20;
-//    IFS0bits.T2IF = 0;
-//}
-
+/**
+ * Initializes Timer4 as a 1ms, 16-bit timer
+ */
 void initTimer4(){
     T4CONbits.TON = 0; // Disable Timer
     T4CONbits.TCS = 0; // Select internal instruction cycle clock
@@ -32,6 +42,9 @@ void initTimer4(){
     T4CONbits.TON = 1; // Start Timer
 }
 
+/**
+ * Timer4 interrupt. Executed every ms
+ */
 void __attribute__((__interrupt__, no_auto_psv)) _T4Interrupt(void){
     time += 1;
     IFS1bits.T4IF = 0;

--- a/Autopilot/AttitudeManager/timer.h
+++ b/Autopilot/AttitudeManager/timer.h
@@ -1,26 +1,28 @@
 /* 
- * File:   timer.h
- * Author: Chris Hajduk
- *
- * Created on September 2, 2015, 3:37 PM
+ * @file timer.h
+ * @author Chris Hajduk
+ * @created September 2, 2015, 3:37 PM
+ * @description Provides functions for initializing the timers (only Timers 2 and 4 used)
+ * as well as getting the current system time
  */
 
 #ifndef TIMER_H
 #define	TIMER_H
 
+/**
+ * Initializes Timer2. Its used as a 16-bit timer. Used for PWM input management
+ */
+void initTimer2(void);
 
-#ifdef	__cplusplus
-extern "C" {
+/**
+ * Initializes Timer4. Used as a 16-bit, interrupt enabled, 1ms timer
+ */
+void initTimer4(void);
+
+/**
+ * Get current time in ms
+ * @return ms
+ */
+long int getTime();
+
 #endif
-
-
-    void initTimer4();
-    long int getTime();
-
-
-#ifdef	__cplusplus
-}
-#endif
-
-#endif	/* TIMER_H */
-


### PR DESCRIPTION
**Changes**:
- Renamed some of the variable names and put in more documentation describing the input compare module (used for PWM)
- Moved initTimer2 function into the timer.h and timer.c modules
- Declared necessary variables in InputCompare.c and .h as static if applicable
- Fixed bug where intermittently PWM values would read extremely low (~-31000) and extremely high (~31000). This was because we were using a signed integer variable to read the timer2 values to be used for comparisons (should be an unsigned integer)
- Fixed issue with hot swapping PWM cables by clearing out the input compare buffer after every read

This branch was thoroughly tested using an RC receiver and all 8 channels. Consistent PWM values were received for all 8 channels