### PR TITLE
Refactored and documented PWM and OutputCompare Modules

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -973,7 +973,7 @@ int writeDatalink(p_priority packet){
             statusData->data.p2_block.ch6In = input[5];
             statusData->data.p2_block.ch7In = input[6];
             statusData->data.p2_block.ch8In = input[7];
-            output = checkPWMArray();
+            output = getPWMOutputs();
             statusData->data.p2_block.ch1Out = output[0];
             statusData->data.p2_block.ch2Out = output[1];
             statusData->data.p2_block.ch3Out = output[2];

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -399,7 +399,7 @@ void inputCapture(){
 
 int getPitchAngleInput(char source){
     if (source == PITCH_RC_SOURCE){
-        return (int)((input_RC_PitchRate / ((float)SP_RANGE / MAX_PITCH_ANGLE) ));
+        return (int)((input_RC_PitchRate / ((float)HALF_PWM_RANGE / MAX_PITCH_ANGLE) ));
     }
     else if (source == PITCH_GS_SOURCE){
         return input_GS_Pitch;
@@ -419,7 +419,7 @@ int getPitchRateInput(char source){
 }
 int getRollAngleInput(char source){
     if (source == ROLL_RC_SOURCE){
-        return (int)((input_RC_RollRate / ((float)SP_RANGE / MAX_ROLL_ANGLE) ));
+        return (int)((input_RC_RollRate / ((float)HALF_PWM_RANGE / MAX_ROLL_ANGLE) ));
     }
     else if (source == ROLL_GS_SOURCE){
         return input_GS_Roll;
@@ -440,7 +440,7 @@ int getRollRateInput(char source){
 }
 int getYawAngleInput(char source){
     if (source == YAW_RC_SOURCE){
-        return (int)((input_RC_YawRate / ((float)SP_RANGE / MAX_ROLL_ANGLE) ));
+        return (int)((input_RC_YawRate / ((float)HALF_PWM_RANGE / MAX_ROLL_ANGLE) ));
     }
     else if (source == YAW_GS_SOURCE){
         return input_GS_Yaw;
@@ -603,13 +603,13 @@ int headingControl(int setpoint, int sensor){
 
 int rollAngleControl(int setpoint, int sensor){
     //Roll Angle
-    sp_ComputedRollRate = controlSignalAngles(setpoint, sensor, ROLL, -(SP_RANGE) / (MAX_ROLL_ANGLE));
+    sp_ComputedRollRate = controlSignalAngles(setpoint, sensor, ROLL, -(HALF_PWM_RANGE) / (MAX_ROLL_ANGLE));
     return sp_ComputedRollRate;
 }
 
 int pitchAngleControl(int setpoint, int sensor){
     //Pitch Angle
-    sp_ComputedPitchRate = controlSignalAngles(setpoint, sensor, PITCH, -(SP_RANGE) / (MAX_PITCH_ANGLE)); //Removed negative
+    sp_ComputedPitchRate = controlSignalAngles(setpoint, sensor, PITCH, -(HALF_PWM_RANGE) / (MAX_PITCH_ANGLE)); //Removed negative
     return sp_ComputedPitchRate;
 }
 

--- a/Autopilot/AttitudeManager/OrientationControl.h
+++ b/Autopilot/AttitudeManager/OrientationControl.h
@@ -27,8 +27,8 @@
 #define SERVO_SCALE_FACTOR (-MAX_PWM / 45.0)
 #define ALTITUDE_PITCH_SCALE_FACTOR 1 //0.1 degrees per meter in altitude change
 #define HEADING_ROLL_SCALE_FACTOR 0.5
-#define THROTTLE_SCALE_FACTOR SP_RANGE///Remove this * 2 if having problems
-#define FLAP_SCALE_FACTOR SP_RANGE
+#define THROTTLE_SCALE_FACTOR HALF_PWM_RANGE///Remove this * 2 if having problems
+#define FLAP_SCALE_FACTOR HALF_PWM_RANGE
 
 
 

--- a/Autopilot/AttitudeManager/OutputCompare.c
+++ b/Autopilot/AttitudeManager/OutputCompare.c
@@ -1,170 +1,92 @@
 /* 
- * File:   OutputCompare.c
- *
- * Created on February 9, 2010, 10:53 AM
+ * @file OutputCompare.c
+ * @created February 9, 2010, 10:53 AM
  */
 
 #include <p33Fxxxx.h>
 #include "OutputCompare.h"
 #include "InputCapture.h"
 
-char initializedOC;
-
-/*
- * 
- */
-
-void init_oc1(void)
+void setOCValue(unsigned int channel, unsigned int duty)
 {
-// Initialize Output Compare Module
-OC1CONbits.OCM = 0b000; // Disable Output Compare Module
-OC1R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC1RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC1CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC1CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc2(void)
-{
-// Initialize Output Compare Module
-OC2CONbits.OCM = 0b000; // Disable Output Compare Module
-OC2R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC2RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC2CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC2CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-void init_oc3(void)
-{
-// Initialize Output Compare Module
-OC3CONbits.OCM = 0b000; // Disable Output Compare Module
-OC3R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC3RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC3CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC3CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc4(void)
-{
-// Initialize Output Compare Module
-OC4CONbits.OCM = 0b000; // Disable Output Compare Module
-OC4R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC4RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC4CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC4CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc5(void)
-{
-//Initialize Output Compare Module
-OC5CONbits.OCM = 0b000; // Disable Output Compare Module
-OC5R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC5RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC5CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC5CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc6(void)
-{
-// Initialize Output Compare Module
-OC6CONbits.OCM = 0b000; // Disable Output Compare Module
-OC6R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC6RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC6CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC6CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc7(void)
-{
-// Initialize Output Compare Module
-OC7CONbits.OCM = 0b000; // Disable Output Compare Module
-OC7R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC7RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC7CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC7CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-void init_oc8(void)
-{
-// Initialize Output Compare Module
-OC8CONbits.OCM = 0b000; // Disable Output Compare Module
-OC8R = MIDDLE_PWM; // Write the duty cycle for the first PWM pulse = 1.5ms/4688
-OC8RS = MIDDLE_PWM; // Write the duty cycle for the second PWM pulse] = 1.5ms/4688
-OC8CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
-OC8CONbits.OCM = 0b110; // Select the Output Compare mode (without fault protection)
-}
-
-/**
- * Set the period value of Timer2
- * @param time Time in ms
- */
-void setPeriod(double time) 
-{
-         T2CONbits.TCKPS = 0x02; //1:64 scaler
-         PR2 = (unsigned int)(time * MSEC);
-}
-
-void setOCValue(int ocPin, int time)
-{
-    //Sets the PWM for subsequent pulses
-    if (ocPin == 1)
-    {
-        OC1RS = time;
-    }
-    else if (ocPin == 2)
-    {
-        OC2RS = time;
-    }
-    else if (ocPin == 3)
-    {
-        OC3RS = time;
-    }
-    else if (ocPin == 4)
-    {
-        OC4RS = time;
-    }
-    else if (ocPin == 5)
-    {
-        OC5RS = time;
-    }
-    else if (ocPin == 6)
-    {
-        OC6RS = time;
-    }
-    else if (ocPin == 7)
-    {
-        OC7RS = time;
-    }
-    else if (ocPin == 8)
-    {
-        OC8RS = time;
+    switch(channel){
+    case 0:
+        OC1RS = duty;
+        break;
+    case 1:
+        OC2RS = duty;
+        break;
+    case 2:
+         OC3RS = duty;
+         break;
+    case 3:
+        OC4RS = duty;
+        break;
+    case 4:
+        OC5RS = duty;
+        break;
+    case 5:
+        OC6RS = duty;
+        break;
+    case 6:
+        OC7RS = duty;
+        break;
+    case 7:
+        OC8RS = duty;
+        break;
     }
 }
 
-void init_oc(char OC)
+void initOC(char OC)
 {
     //Initialize each of the 8 OCs
-    if (OC & 0b1)
-        init_oc1();
-    if (OC & 0b10)
-        init_oc2();
-    if (OC & 0b100)
-        init_oc3();
-    if (OC & 0b1000)
-        init_oc4();
-    if (OC & 0b10000)
-        init_oc5();
-    if (OC & 0b100000)
-        init_oc6();
-    if (OC & 0b1000000)
-        init_oc7();
-    if (OC & 0b10000000)
-        init_oc8();
-}
+    if (OC & 0b1) {
+        OC1CONbits.OCM = 0b000; // Disable Output Compare Module )required to set it as something else)
+        OC1RS = 0x00; // Write a duty cycle of 0 to start off with
+        OC1CONbits.OCTSEL = 0; // Select Timer 2 as output compare time base
+        OC1CONbits.OCM = 0b110; // Select the Output Compare mode (PWM without fault protection)
+    }
+    if (OC & 0b10) {
+        OC2CONbits.OCM = 0b000;
+        OC2RS = 0x00;
+        OC2CONbits.OCTSEL = 0;
+        OC2CONbits.OCM = 0b110;
 
-void initOC(char OC){ //int argc, char** argv) {
-    init_oc(OC);
-    //Initialize timer2
-    initializedOC = OC;
-    //init_t2();
-
+    }
+    if (OC & 0b100) {
+        OC3CONbits.OCM = 0b000;
+        OC3RS = 0x00;
+        OC3CONbits.OCTSEL = 0;
+        OC3CONbits.OCM = 0b110;
+    }
+    if (OC & 0b1000) {
+        OC4CONbits.OCM = 0b000;
+        OC4RS = 0x00;
+        OC4CONbits.OCTSEL = 0;
+        OC4CONbits.OCM = 0b110;
+    }
+    if (OC & 0b10000) {
+        OC5CONbits.OCM = 0b000;
+        OC5RS = 0x00;
+        OC5CONbits.OCTSEL = 0;
+        OC5CONbits.OCM = 0b110;
+    }
+    if (OC & 0b100000) {
+        OC6CONbits.OCM = 0b000;
+        OC6RS = 0x00;
+        OC6CONbits.OCTSEL = 0;
+        OC6CONbits.OCM = 0b110;
+    }
+    if (OC & 0b1000000) {
+        OC7CONbits.OCM = 0b000;
+        OC7RS = 0x00;
+        OC7CONbits.OCTSEL = 0;
+        OC7CONbits.OCM = 0b110;
+    }
+    if (OC & 0b10000000) {
+        OC8CONbits.OCM = 0b000;
+        OC8RS = 0x00;
+        OC8CONbits.OCTSEL = 0;
+        OC8CONbits.OCM = 0b110;
+    }
 }

--- a/Autopilot/AttitudeManager/OutputCompare.h
+++ b/Autopilot/AttitudeManager/OutputCompare.h
@@ -1,211 +1,26 @@
 /* 
- * File:   main.h
- * Author: Chris Hajduk
- *
- * Created on March 3, 2013, 12:42 AM
+ * @file OutputCompare.h
+ * @author Chris Hajduk
+ * @created March 3, 2013, 12:42 AM
+ * @desription Provides functions for utilizing the output compare feature of the
+ * chip. Basically lets you control the output of the PWM capable pins.
  */
 
 #ifndef OUTPUTCAPTURE_H
 #define	OUTPUTCAPTURE_H
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
-#define MSEC 642//470
-#define UPPER_PWM 1284//1320//1411//941
-#define LOWER_PWM 642//705//470
-#define MIDDLE_PWM 963//981//(int)((UPPER_PWM - LOWER_PWM)/2) + LOWER_PWM//706
-#define SP_RANGE MAX_PWM//(UPPER_PWM - MIDDLE_PWM)
-
-
-
-/*****************************************************************************
- * Function: init_oc1
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- * 
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc1(void);
-
-/*****************************************************************************
- * Function: init_oc2
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc2(void);
-
-/*****************************************************************************
- * Function: init_oc3
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc3(void);
-
-/*****************************************************************************
- * Function: init_oc4
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc4(void);
-
-/*****************************************************************************
- * Function: init_oc5
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc5(void);
-
-/*****************************************************************************
- * Function: init_oc6
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc6(void);
-
-/*****************************************************************************
- * Function: init_oc7
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc7(void);
-
-/*****************************************************************************
- * Function: init_oc8
- *
- * Preconditions: None.
- *
- * Overview: Initializes the output compare registers with default pwm of 1.5ms
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc8(void);
-
-/*****************************************************************************
- * Function: init
- *
- * Preconditions: None.
- *
- * Overview: Initializes all the output compare pins and timers
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
-void init_oc(char OC);
-
-/*****************************************************************************
- * Function: init
- *
- * Preconditions: None.
- *
- * Overview: Initializes all the output compare pins and timers
- *
- *
- * Input: None.
- *
- * Output: None.
- *
- *****************************************************************************/
+/**
+ * Initializes the output compare registers and pins for PWM output. Writes a 1.5 ms
+ * duty cycle on the selected channels to start off with
+ * @param OC 8-bit bit mask indicating which pins to enable for output
+ */
 void initOC(char OC);
 
-/*****************************************************************************
- * Function: setPWM
- *
- * Preconditions: None.
- *
- * Overview: Changes or sets the PWM of a given OC pin from a percentage.
- *
- *
- * Input: int ocPin - pin to make the change to.
- *        int percent - percent of the total (2ms) pulse to output.
- *
- * Output: None.
- *
- *****************************************************************************/
+/**
+ * Sets the PWM of a given output pin
+ * @param channel Number from 0-7
+ * @param time Time/duty cycle in Timer2 ticks, not ms
+ */
+void setOCValue(unsigned int channel, unsigned int duty);
 
-void setOCValue(int ocPin, int time);
-
-/*****************************************************************************
- * Function: setPeriod
- *
- * Preconditions: None.
- *
- * Overview: Changes or sets the period of timer 2, to alter ALL output
- * compare frequencies
- *
- *
- * Input: double time - time in milliseconds for the output compare *
- *
- * Output: None.
- *
- *****************************************************************************/
-
-void setPeriod(double time);
-
-#ifdef	__cplusplus
-}
 #endif
-
-#endif	/* OUTPUTCAPTURE_H */

--- a/Autopilot/AttitudeManager/OutputCompare.h
+++ b/Autopilot/AttitudeManager/OutputCompare.h
@@ -3,7 +3,7 @@
  * @author Chris Hajduk
  * @created March 3, 2013, 12:42 AM
  * @desription Provides functions for utilizing the output compare feature of the
- * chip. Basically lets you control the output of the PWM capable pins.
+ * chip. Basically lets you set the PWM duty cycle for one of the 8 output channels
  */
 
 #ifndef OUTPUTCAPTURE_H

--- a/Autopilot/AttitudeManager/PWM.c
+++ b/Autopilot/AttitudeManager/PWM.c
@@ -89,8 +89,9 @@ void calibratePWMOutputs(unsigned int channel, float signalScaleFactor, unsigned
  * Calculates/scales the input capture value of every channel to the PWM range
  */
 static void calculatePWM(void){
+    unsigned int* ic_values = getICValues();
     int channel = 0;
     for (channel = 0; channel < NUM_CHANNELS; channel++){
-        pwm_inputs[channel] = (int)((getICValue(channel) - input_offsets[channel]) * input_scale_factors[channel]);
+        pwm_inputs[channel] = (int)((ic_values[channel] - input_offsets[channel]) * input_scale_factors[channel]);
     }
 }

--- a/Autopilot/AttitudeManager/PWM.c
+++ b/Autopilot/AttitudeManager/PWM.c
@@ -18,6 +18,7 @@ float scaleFactorOut[NUM_CHANNELS];
 int offsetOut[NUM_CHANNELS];
 
 void initPWM(char inputChannels, char outputChannels){
+    initTimer2();
     initIC(inputChannels);
     int i = 0;
     for (i = 0; i < NUM_CHANNELS; i++){
@@ -98,7 +99,7 @@ int* getPWMArray(){
 void setPWM(unsigned int channel, int pwm){
     if (initialized && channel > 0 && channel <= NUM_CHANNELS){ //Is the Input Initialized?
         checkArray[channel - 1] = pwm;
-        setOCValue(channel, (int)(pwm * scaleFactorOut[channel - 1] + offsetOut[channel - 1]));
+        setOCValue(channel - 1, (int)(pwm * scaleFactorOut[channel - 1] + offsetOut[channel - 1]));
     }
     else { //Not initialized or invalid channel
         //Display Error Message

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -20,6 +20,12 @@ extern "C" {
 #define MAX_PWM 1024
 #define MIN_PWM -1024
 
+//TODO: These were defined in OutputCompare.h    
+#define UPPER_PWM 1284//1320//1411//941
+#define LOWER_PWM 642//705//470
+#define MIDDLE_PWM 963//981//(int)((UPPER_PWM - LOWER_PWM)/2) + LOWER_PWM//706
+#define SP_RANGE MAX_PWM//(UPPER_PWM - MIDDLE_PWM)
+
 // Function Prototypes
 /*****************************************************************************
  * Function: void initPWM(char inputChannels, char outputChannels);

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -36,7 +36,7 @@
 #define UPPER_PWM 1284
 #define LOWER_PWM 642
 
-#define SP_RANGE MAX_PWM//(UPPER_PWM - MIDDLE_PWM)
+#define HALF_PWM_RANGE (MAX_PWM - MIN_PWM)/2
 
 /**
  * Initializes the PWM input and output channels. Also initializes Timer2

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -53,20 +53,6 @@ void initPWM(char inputChannels, char outputChannels);
  */
 int* getPWMArray();
 
-/*****************************************************************************
- * Function: void setPWM(unsigned int channel, int pwm);
- *
- * Preconditions: The PWM outputs must have been initialized for valid output.
- *
-  Overview: Sets the output through the output compare pins on the device.
- *
- * Input: unsigned int channel -> The channel that is being set.
- *        int pwm -> The value (usually between +-1024) that is to be set to the
- *                  output compare pins.
- *
- * Output: None.
- *
- *****************************************************************************/
 /**
  * Sets the PWM output of a particular output. Make sure initPWM is called before
  * this, otherwise unexpected behavior will occur

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -31,7 +31,7 @@
  * Maximum and minimum limits received from the controller. These should be calibrated,
  * and the scaling from these values to the MAX and MIN PWM values will depend on these.
  * Note that these will be used as the default/initial values, however the actual scaling values
- * can be set by the groundstation
+ * can be set by the ground station
  */
 #define UPPER_PWM 1284
 #define LOWER_PWM 642
@@ -46,7 +46,7 @@
 void initPWM(char inputChannels, char outputChannels);
 
 /**
- * Gets the scaled PWM values in the rnage of MIN_PWM and MAX_PWM from all the channels.
+ * Gets the scaled PWM values in the range of MIN_PWM and MAX_PWM from all the channels.
  * Make sure that initPWM is called before calling this, otherwise the results will be useless
  * @return An integer array of size 8 containing the PWM values for all the channels. Note that
  * this array is zero-indexed, so channel 1 is index 0 (unlike the getPWM function)

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -36,6 +36,9 @@
 #define UPPER_PWM 1284
 #define LOWER_PWM 642
 
+/**
+ * Used in some of the calculations
+ */
 #define HALF_PWM_RANGE (MAX_PWM - MIN_PWM)/2
 
 /**

--- a/Autopilot/AttitudeManager/cameraManager.h
+++ b/Autopilot/AttitudeManager/cameraManager.h
@@ -11,7 +11,7 @@
 #include "OutputCompare.h"
 
 //Constants
-#define GIMBAL_PWM_RANGE SP_RANGE //Range one way (IE. Positive or Negative range, not both)
+#define GIMBAL_PWM_RANGE HALF_PWM_RANGE //Range one way (IE. Positive or Negative range, not both)
 #define GIMBAL_MOTION_RANGE 30 //Range one way
 #define LEFT_GIMBAL_MOTION_LIMIT 30 //Range Left way
 #define RIGHT_GIMBAL_MOTION_LIMIT 30 //Range Right way

--- a/Autopilot/AttitudeManager/timer.c
+++ b/Autopilot/AttitudeManager/timer.c
@@ -19,7 +19,8 @@ void initTimer2(void)
     T2CONbits.TCS = 0; // Select internal instruction cycle clock
     T2CONbits.TGATE = 0; // Disable Gated Timer mode
     TMR2 = 0x00; // Clear timer register
-    setPeriod(20); // Load the period value = 20ms. Required for proper output compare                
+    T2CONbits.TCKPS = 0x02; //1:64 scaler
+    PR2 = T2_PERIOD * T2_TICKS_TO_MSEC; //set the period
     IPC1bits.T2IP = 0x01; // Set Timer 2 Interrupt Priority Level - Lowest
     IFS0bits.T2IF = 0; // Clear Timer 2 Interrupt Flag
     IEC0bits.T2IE = 0; // Disable Timer 2 interrupt

--- a/Autopilot/AttitudeManager/timer.h
+++ b/Autopilot/AttitudeManager/timer.h
@@ -10,7 +10,24 @@
 #define	TIMER_H
 
 /**
- * Initializes Timer2. Its used as a 16-bit timer. Used for PWM input management
+ * Number of Timer2 ticks in a millisecond. To calculate this, take:
+ * 1/(frequencyCPU/Timer2PreScaler)*TICKS_TO_MSEC should equal close to 0.001 or 1 ms
+ * In this case, (1/(41Mhz/64))*642 == ~1ms
+ * 
+ * This value is used to accurately define the timer2 period (used for output pwm
+ * frequency
+ */
+#define T2_TICKS_TO_MSEC 642
+
+/**
+ * Timer2 Period in ms. When the period is reached, the timer is reset. 
+ * Since Timer2 is used in the output compare (PWM output), this period defines 
+ * the period of the PWM as well. If you want 50Hz, set this as 20ms
+ */
+#define T2_PERIOD 20
+
+/**
+ * Initializes Timer2. Its used as a 16-bit timer. Used for PWM input and output management
  */
 void initTimer2(void);
 


### PR DESCRIPTION
**Changes**:
- Documented OutputCompare and PWM modules
- Moved out Timer2 logic into the timer module (such as setting Timer2 period, etc)
- Moved the TImer2 initialization call to the PWM module (used to be in InputCompare)
- Removed any unused functions from PWM, InputCompare, and OutputCompare modules
- renamed and moved around the define statements to make more sense

Note that this is only a refactor, however hasn't been tested yet. I'll test this afterwords with an integration test