### PR TITLE
New UHF Disconnect detection

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -1037,13 +1037,20 @@ int writeDatalink(p_priority packet){
 }
 
 void checkUHFStatus(){
-    if (input_RC_UHFSwitch > 429 && input_RC_UHFSwitch < 440){
-        setProgramStatus(KILL_MODE_WARNING);
-        if (getTime() - UHFTimer > UHF_KILL_TIMEOUT){
-            killPlane(TRUE);
+    unsigned long int time = getTime();
+    
+    if (!isPWMAlive(time)){
+        if (UHFTimer == 0){ //0 indicates that this is the first time we lost UHF
+            UHFTimer = time;
+            setProgramStatus(KILL_MODE_WARNING);
+        } else { //otherwise check if we're over the threshold
+            if (time - UHFTimer > UHF_KILL_TIMEOUT){
+                killPlane(TRUE);
+            }
         }
+    } else {
+        UHFTimer = 0; //set it back to 0 otherwise to reset state
     }
-
 }
 
 void checkHeartbeat(){

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -24,6 +24,13 @@ static char new_data_available[8];
  */
 static unsigned int capture_value[8];
 
+/**
+ * Used to detect a UHF disconnect. Keeps track of the last time a falling edge
+ * was detected. Currently on the Channel 7 ISR will change this variable, however
+ * this can be configured to be any one of the other channels
+ */
+static unsigned long int last_capture_time;
+
 static void calculateICValue(unsigned char channel);
 
 unsigned int* getICValues()
@@ -40,6 +47,10 @@ unsigned int getICValue(unsigned char channel)
 {
     calculateICValue(channel);
     return capture_value[channel];
+}
+
+unsigned long int getICLastCapturedTime(void){
+    return last_capture_time;
 }
 
 /**
@@ -285,6 +296,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC7Interrupt(void)
     } else {
         end_time[6] = IC7BUF;
         new_data_available[6] = 1;
+        last_capture_time = getTime(); //Capture the time. Used for detecting disconnects
     }
 
     while (IC7CONbits.ICBNE) {

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -5,6 +5,12 @@
  * @description This file provides the methods necessary to access the input capture
  * capabilities of the chip. In essence, it lets you get the raw, uncalibrated PWM values 
  * from the 8 available input compare channels
+ * 
+ * Channel 7 is specifically also configured as the UHF connection switch. An edge
+ * detected on channel 7 will signify that the UHF is still alive by saving a timestamp
+ * which can be compared later. This can be reconfigured to a different channel, however
+ * the position of the timestamp save must be placed in a different interrupt service
+ * routine.
  */
 
 #ifndef INPUTCAPTURE_H
@@ -31,5 +37,12 @@ unsigned int* getICValues();
  * The timer module defines number of ticks in a ms
  */
 unsigned int getICValue(unsigned char channel);
+
+/**
+ * Get the last system time an edge was detected on channel 7. Should be used
+ * for detecting a UHF disconnect
+ * @return System time in ms since the last detected edge/data on channel 7
+ */
+unsigned long int getICLastCapturedTime(void);
 
 #endif

--- a/Autopilot/AttitudeManager/PWM.c
+++ b/Autopilot/AttitudeManager/PWM.c
@@ -71,6 +71,13 @@ int* getPWMOutputs(){
     return pwm_outputs;
 }
 
+char isPWMAlive(unsigned long int sys_time){
+    if ((sys_time - getICLastCapturedTime()) <= PWM_ALIVE_THRESHOLD){
+        return 1;
+    }
+    return 0;
+}
+
 void calibratePWMInputs(unsigned int channel, float signalScaleFactor, unsigned int signalOffset){
     if (channel > 0 && channel <= NUM_CHANNELS){ //Check if channel number is valid
         input_scale_factors[channel - 1] = signalScaleFactor;

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -42,6 +42,12 @@
 #define HALF_PWM_RANGE (MAX_PWM - MIN_PWM)/2
 
 /**
+ * Number of ms after the last detected edge on channel 7 that it can be assumed
+ * the UHF connection is lost/PWM dead
+ */
+#define PWM_ALIVE_THRESHOLD 100
+
+/**
  * Initializes the PWM input and output channels. Also initializes Timer2
  * @param inputChannels 8-bit bit mask indicating which inputs to initialize (probably want to send 0xFF for all)
  * @param outputChannels 8-bit bit mask indicating which outputs to initialize
@@ -72,6 +78,13 @@ void setPWM(unsigned int channel, int pwm);
  *      for all the channels. Note the array is 0-indexed, so channel 1 is array index 0
  */
 int* getPWMOutputs();
+
+/**
+ * Checks PWM based on last data received on channel 7
+ * @param sys_time The current system time in ms
+ * @return 1 if the UHF connection is still alive, otherwise returns 0
+ */
+char isPWMAlive(unsigned long int sys_time);
 
 /**
  * Calibrates the input range and trim of a PWM channel input

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -9,6 +9,9 @@
  * 
  * Note that this is the module that scales the PWM inputs from the RC controller
  * range to the -1024 to 1024 range, as well as scales the outputs in the opposite manner.
+ * 
+ * Also note that channel 7 input by default is set as the UHF keep alive channel,
+ * and is tracked to for detecting UHF loss
  */
 
 #ifndef PWM_H

--- a/Autopilot/AttitudeManager/timer.c
+++ b/Autopilot/AttitudeManager/timer.c
@@ -8,7 +8,7 @@
 #include "main.h"
 #include "timer.h"
 
-static long int time = 0;
+static unsigned long int time = 0;
 
 /**
  * Initializes Timer2. Its used as a 16-bit timer
@@ -51,6 +51,6 @@ void __attribute__((__interrupt__, no_auto_psv)) _T4Interrupt(void){
     IFS1bits.T4IF = 0;
 }
 
-long int getTime(){
+long unsigned int getTime(){
     return time;
 }

--- a/Autopilot/AttitudeManager/timer.h
+++ b/Autopilot/AttitudeManager/timer.h
@@ -40,6 +40,6 @@ void initTimer4(void);
  * Get current time in ms
  * @return ms
  */
-long int getTime();
+long unsigned int getTime();
 
 #endif


### PR DESCRIPTION
**Changes**:
- Time is now an unsigned integer (instead of signed int) which makes more sense
- New UHF disconnect logic. Instead of using a separate UHF channel and comparing its value between two min and max thresholds, detection is now done by tracking the last time an edge was detected on an arbitrary channel. For this to work the RC receivers must be configured to disable their PWM outputs on a disconnect, thus their fail safe options must be disabled. This was done on the orange RX already, and can be done on the ezUHF as well as most likely the dragon link
- Re-write checkUHFStatus function in AttitudeManager. I noticed a bug in that UHFTimer was always 0 (never set), thus if competition mode was turned on and a uhf disconnect occured, the plane would go into kill mode immediately.

Only 1 channel was chosen (channel 7) for the detection logic since it requires calling an external function inside an ISR, which I wanted to limit. Channel 7 was chosen as this will be the RSSI input channel, which will be configured in a later PR

**Note**
This has not been tested yet. I'll test this along with the other changes in an upcoming workday