### PR TITLE
Added option for showing non-scaled PWM output

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -148,6 +148,8 @@ char lastNumSatellites = 0;
 
 unsigned int cameraCounter = 0;
 
+char show_scaled_pwm = 1;
+
 void attitudeInit() {
     setProgramStatus(INITIALIZATION);
     //Initialize Timer
@@ -867,6 +869,13 @@ void readDatalink(void){
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
+            case SHOW_SCALED_PWM:
+                if ((*(char*)(&cmd->data)) == 1){
+                    show_scaled_pwm = 1;
+                } else{
+                    show_scaled_pwm = 0;
+                }
+                break;
             case NEW_WAYPOINT:
                 amData.waypoint = *(WaypointWrapper*)(&cmd->data);
                 amData.command = PM_NEW_WAYPOINT;
@@ -964,7 +973,11 @@ int writeDatalink(p_priority packet){
             statusData->data.p2_block.batteryLevel1 = batteryLevel1;
             statusData->data.p2_block.batteryLevel2 = batteryLevel2;
 //            debug("SW3");
-            input = getPWMArray();
+            if (show_scaled_pwm){
+                input = getPWMArray();
+            } else {
+                input = getICValues();
+            }
             statusData->data.p2_block.ch1In = input[0];
             statusData->data.p2_block.ch2In = input[1];
             statusData->data.p2_block.ch3In = input[2];

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -278,7 +278,7 @@ char checkDMA(){
         DMA0CONbits.CHEN = 0; //Disable DMA0 channel
         DMA1CONbits.CHEN = 0; //Disable DMA1 channel
         while(SPI1STATbits.SPIRBF) { //Clear SPI1
-            int dummy = SPI1BUF;
+            SPI1BUF;
         }
 //        INTERCOM_2 = 0;
 //        while(INTERCOM_4);

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -976,7 +976,7 @@ int writeDatalink(p_priority packet){
             if (show_scaled_pwm){
                 input = getPWMArray();
             } else {
-                input = getICValues();
+                input = (int*)getICValues();
             }
             statusData->data.p2_block.ch1In = input[0];
             statusData->data.p2_block.ch2In = input[1];

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -158,8 +158,11 @@ void attitudeInit() {
     //Initialize Interchip communication
     TRISFbits.TRISF3 = 0;
     LATFbits.LATF3 = 1;
-
-    TRISDbits.TRISD14 = 0;
+    
+    //the line below sets channel 7 IC to be an output. Used to be for DMA. Should
+    //investigate DMA code to see why this was used in the first place, and if it'll have
+    //any negative consequences. Commenting out for now. Serge Feb 7 2017
+    //TRISDbits.TRISD14 = 0;
     LATDbits.LATD14 = 0;
 
     amData.checkbyteDMA = generateAMDataDMACheckbyte();

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -19,7 +19,8 @@
 #include "main.h"
 
 /**
- * Initializes capture configuration of the PWM input channels.
+ * Initializes capture configuration of the PWM input channels. Make sure to initialize Timer2
+ * before calling this!
  * @param initIC An 8-bit bitmask specifying which channels to enable (will enable interrupts on these)
  */
 void initIC(char initIC);

--- a/Autopilot/AttitudeManager/StateMachine.c
+++ b/Autopilot/AttitudeManager/StateMachine.c
@@ -177,10 +177,10 @@ void lowLevelControl(){
     checkLimits(outputSignal);
     //Then Output
     unsigned int cameraCounter = 0; //TODO: TEMPORARY, STORE TIME NOT COUNTER (OR BOTH) IMPLEMENT THIS A BETTER WAY
-    unsigned int cameraPWM = cameraPollingRuntime(getLatitude(), getLongitude(), getTime(), &cameraCounter, getRoll(), getPitch());
-    unsigned int gimbalPWM = cameraGimbalStabilization(getRoll());
-    unsigned int goProGimbalPWM = goProGimbalStabilization(getRoll());
-    unsigned int verticalGoProPWM = goProVerticalstabilization(getPitch());
+    cameraPollingRuntime(getLatitude(), getLongitude(), getTime(), &cameraCounter, getRoll(), getPitch());
+    cameraGimbalStabilization(getRoll());
+    goProGimbalStabilization(getRoll());
+    goProVerticalstabilization(getPitch());
     //For fixed-wing aircraft: Typically 0 = Roll, 1 = Pitch, 2 = Throttle, 3 = Yaw
 
     if (!killingPlane){

--- a/Autopilot/AttitudeManager/VN_user.c
+++ b/Autopilot/AttitudeManager/VN_user.c
@@ -78,7 +78,6 @@ void VN_SPI_SetSS(unsigned char sensorID, VN_PinState state){
 *******************************************************************************/
 unsigned long VN_SPI_SendReceive(unsigned long data){
 
-char smAllowed = getProgramStatus() > ARMING;
 /* User code to send out 4 bytes over SPI goes here */
   unsigned long ret = 0;
     /* Wait for SPI1 Tx buffer empty */
@@ -88,7 +87,7 @@ char smAllowed = getProgramStatus() > ARMING;
     /* Send SPI1 requests */
     //SPI_I2S_SendData(SPI1, VN_BYTE(data, i));
 	SPI2BUF = VN_BYTE4(data);
-        while (SPI2STATbits.SPITBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+        while (SPI2STATbits.SPITBF){
         }
     /* Wait for response from VN-100 */
     //while (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_RXNE) == RESET);
@@ -99,7 +98,7 @@ char smAllowed = getProgramStatus() > ARMING;
     //ret |= ((unsigned long)SPI_I2S_ReceiveData(SPI1) << (8*i));
 	ret |= ((unsigned long)SPI2BUF << (0));
 
-  	while (SPI2STATbits.SPITBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (SPI2STATbits.SPITBF){
         }
     /* Send SPI1 requests */
     //SPI_I2S_SendData(SPI1, VN_BYTE(data, i));
@@ -107,13 +106,13 @@ char smAllowed = getProgramStatus() > ARMING;
 
     /* Wait for response from VN-100 */
     //while (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_RXNE) == RESET);
-  	while (!SPI2STATbits.SPIRBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (!SPI2STATbits.SPIRBF){
         }
     /* Save received data in buffer */
     //ret |= ((unsigned long)SPI_I2S_ReceiveData(SPI1) << (8*i));
 	ret |= ((unsigned long)SPI2BUF << (8));
 
-  	while (SPI2STATbits.SPITBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (SPI2STATbits.SPITBF){
         }
     /* Send SPI1 requests */
     //SPI_I2S_SendData(SPI1, VN_BYTE(data, i));
@@ -121,14 +120,14 @@ char smAllowed = getProgramStatus() > ARMING;
 
     /* Wait for response from VN-100 */
     //while (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_RXNE) == RESET);
-  	while (!SPI2STATbits.SPIRBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (!SPI2STATbits.SPIRBF){
         }
 
     /* Save received data in buffer */
     //ret |= ((unsigned long)SPI_I2S_ReceiveData(SPI1) << (8*i));
 	ret |= ((unsigned long)SPI2BUF << (16));
 
-  	while (SPI2STATbits.SPITBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (SPI2STATbits.SPITBF){
         }
 
     /* Send SPI1 requests */
@@ -137,7 +136,7 @@ char smAllowed = getProgramStatus() > ARMING;
 
     /* Wait for response from VN-100 */
     //while (SPI_I2S_GetFlagStatus(SPI1, SPI_I2S_FLAG_RXNE) == RESET);
-  	while (!SPI2STATbits.SPIRBF){//if (smAllowed){StateMachine(STATEMACHINE_IMU);}
+  	while (!SPI2STATbits.SPIRBF){
         }
     /* Save received data in buffer */
     //ret |= ((unsigned long)SPI_I2S_ReceiveData(SPI1) << (8*i));

--- a/Autopilot/AttitudeManager/commands.h
+++ b/Autopilot/AttitudeManager/commands.h
@@ -68,6 +68,7 @@
 #define RESET_PROBE 57
 #define FOLLOW_PATH 58
 #define EXIT_HOLD_ORBIT 59
+#define SHOW_SCALED_PWM 60
 
 //Multipart Commands
 #define NEW_WAYPOINT 128

--- a/Autopilot/AttitudeManager/nbproject/configurations.xml
+++ b/Autopilot/AttitudeManager/nbproject/configurations.xml
@@ -39,6 +39,7 @@
         <itemPath>delay.h</itemPath>
         <itemPath>fmath.h</itemPath>
         <itemPath>StringUtils.h</itemPath>
+        <itemPath>timer.h</itemPath>
       </logicalFolder>
       <logicalFolder name="f7" displayName="VectorNav" projectFiles="true">
         <itemPath>VN100.h</itemPath>
@@ -99,7 +100,6 @@
         <itemPath>delay.c</itemPath>
         <itemPath>StringUtils.c</itemPath>
         <itemPath>timer.c</itemPath>
-        <itemPath>timer.h</itemPath>
       </logicalFolder>
       <logicalFolder name="f6" displayName="VectorNav" projectFiles="true">
         <itemPath>VN100.c</itemPath>

--- a/Autopilot/Relay/nbproject/Makefile-default.mk
+++ b/Autopilot/Relay/nbproject/Makefile-default.mk
@@ -38,11 +38,20 @@ DEBUGGABLE_SUFFIX=elf
 FINAL_IMAGE=dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}
 endif
 
+ifeq ($(COMPARE_BUILD), true)
+COMPARISON_BUILD=-mafrlcsj
+else
+COMPARISON_BUILD=
+endif
+
 # Object Directory
 OBJECTDIR=build/${CND_CONF}/${IMAGE_TYPE}
 
 # Distribution Directory
 DISTDIR=dist/${CND_CONF}/${IMAGE_TYPE}
+
+# Source Files Quoted if spaced
+SOURCEFILES_QUOTED_IF_SPACED=AutoRelay_v0_01.c
 
 # Object Files Quoted if spaced
 OBJECTFILES_QUOTED_IF_SPACED=${OBJECTDIR}/AutoRelay_v0_01.o
@@ -50,6 +59,9 @@ POSSIBLE_DEPFILES=${OBJECTDIR}/AutoRelay_v0_01.o.d
 
 # Object Files
 OBJECTFILES=${OBJECTDIR}/AutoRelay_v0_01.o
+
+# Source Files
+SOURCEFILES=AutoRelay_v0_01.c
 
 
 CFLAGS=
@@ -66,7 +78,10 @@ LDLIBSOPTIONS=
 FIXDEPS=fixDeps
 
 .build-conf:  ${BUILD_SUBPROJECTS}
-	${MAKE} ${MAKE_OPTIONS} -f nbproject/Makefile-default.mk dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}
+ifneq ($(INFORMATION_MESSAGE), )
+	@echo $(INFORMATION_MESSAGE)
+endif
+	${MAKE}  -f nbproject/Makefile-default.mk dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}
 
 MP_PROCESSOR_OPTION=24F16KA101
 MP_LINKER_FILE_OPTION=,--script=p24F16KA101.gld
@@ -74,16 +89,18 @@ MP_LINKER_FILE_OPTION=,--script=p24F16KA101.gld
 # Rules for buildStep: compile
 ifeq ($(TYPE_IMAGE), DEBUG_RUN)
 ${OBJECTDIR}/AutoRelay_v0_01.o: AutoRelay_v0_01.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} ${OBJECTDIR} 
+	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/AutoRelay_v0_01.o.d 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  AutoRelay_v0_01.c  -o ${OBJECTDIR}/AutoRelay_v0_01.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/AutoRelay_v0_01.o.d"        -g -D__DEBUG -D__MPLAB_DEBUGGER_ICD3=1  -omf=elf -O0 -msmart-io=1 -Wall -msfr-warn=off
+	@${RM} ${OBJECTDIR}/AutoRelay_v0_01.o 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  AutoRelay_v0_01.c  -o ${OBJECTDIR}/AutoRelay_v0_01.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/AutoRelay_v0_01.o.d"      -g -D__DEBUG -D__MPLAB_DEBUGGER_ICD3=1    -omf=elf -no-legacy-libc  $(COMPARISON_BUILD)  -O0 -msmart-io=1 -Wall -msfr-warn=off  
 	@${FIXDEPS} "${OBJECTDIR}/AutoRelay_v0_01.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
 	
 else
 ${OBJECTDIR}/AutoRelay_v0_01.o: AutoRelay_v0_01.c  nbproject/Makefile-${CND_CONF}.mk
-	@${MKDIR} ${OBJECTDIR} 
+	@${MKDIR} "${OBJECTDIR}" 
 	@${RM} ${OBJECTDIR}/AutoRelay_v0_01.o.d 
-	${MP_CC} $(MP_EXTRA_CC_PRE)  AutoRelay_v0_01.c  -o ${OBJECTDIR}/AutoRelay_v0_01.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/AutoRelay_v0_01.o.d"        -g -omf=elf -O0 -msmart-io=1 -Wall -msfr-warn=off
+	@${RM} ${OBJECTDIR}/AutoRelay_v0_01.o 
+	${MP_CC} $(MP_EXTRA_CC_PRE)  AutoRelay_v0_01.c  -o ${OBJECTDIR}/AutoRelay_v0_01.o  -c -mcpu=$(MP_PROCESSOR_OPTION)  -MMD -MF "${OBJECTDIR}/AutoRelay_v0_01.o.d"        -g -omf=elf -no-legacy-libc  $(COMPARISON_BUILD)  -O0 -msmart-io=1 -Wall -msfr-warn=off  
 	@${FIXDEPS} "${OBJECTDIR}/AutoRelay_v0_01.o.d" $(SILENT)  -rsi ${MP_CC_DIR}../ 
 	
 endif
@@ -105,13 +122,13 @@ endif
 ifeq ($(TYPE_IMAGE), DEBUG_RUN)
 dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk    
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -D__DEBUG -D__MPLAB_DEBUGGER_ICD3=1  -omf=elf -Wl,--defsym=__MPLAB_BUILD=1,--defsym=__ICD2RAM=1,--defsym=__MPLAB_DEBUG=1,--defsym=__DEBUG=1,--defsym=__MPLAB_DEBUGGER_ICD3=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem$(MP_EXTRA_LD_POST) 
+	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -D__DEBUG -D__MPLAB_DEBUGGER_ICD3=1  -omf=elf -no-legacy-libc  $(COMPARISON_BUILD)   -mreserve=data@0x800:0x81F -mreserve=data@0x820:0x821 -mreserve=data@0x822:0x823 -mreserve=data@0x824:0x825 -mreserve=data@0x826:0x84F   -Wl,,--defsym=__MPLAB_BUILD=1,--defsym=__MPLAB_DEBUG=1,--defsym=__DEBUG=1,--defsym=__MPLAB_DEBUGGER_ICD3=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST) 
 	
 else
 dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${OUTPUT_SUFFIX}: ${OBJECTFILES}  nbproject/Makefile-${CND_CONF}.mk   
 	@${MKDIR} dist/${CND_CONF}/${IMAGE_TYPE} 
-	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -omf=elf -Wl,--defsym=__MPLAB_BUILD=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem$(MP_EXTRA_LD_POST) 
-	${MP_CC_DIR}\\xc16-bin2hex dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX} -a  -omf=elf 
+	${MP_CC} $(MP_EXTRA_LD_PRE)  -o dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX}  ${OBJECTFILES_QUOTED_IF_SPACED}      -mcpu=$(MP_PROCESSOR_OPTION)        -omf=elf -no-legacy-libc  $(COMPARISON_BUILD)  -Wl,,--defsym=__MPLAB_BUILD=1,$(MP_LINKER_FILE_OPTION),--stack=16,--check-sections,--data-init,--pack-data,--handles,--isr,--no-gc-sections,--fill-upper=0,--stackguard=16,--no-force-link,--smart-io,-Map="${DISTDIR}/${PROJECTNAME}.${IMAGE_TYPE}.map",--report-mem,--memorysummary,dist/${CND_CONF}/${IMAGE_TYPE}/memoryfile.xml$(MP_EXTRA_LD_POST) 
+	${MP_CC_DIR}\\xc16-bin2hex dist/${CND_CONF}/${IMAGE_TYPE}/Relay.${IMAGE_TYPE}.${DEBUGGABLE_SUFFIX} -a  -omf=elf  
 	
 endif
 

--- a/Autopilot/Relay/nbproject/Makefile-local-default.mk
+++ b/Autopilot/Relay/nbproject/Makefile-local-default.mk
@@ -15,23 +15,23 @@
 # $ makeMP_CC="/opt/microchip/mplabc30/v3.30c/bin/pic30-gcc" ...  
 #
 SHELL=cmd.exe
-PATH_TO_IDE_BIN=C:/Program Files (x86)/Microchip/MPLABX/mplab_ide/mplab_ide/modules/../../bin/
+PATH_TO_IDE_BIN=C:/Program Files (x86)/Microchip/MPLABX/v3.30/mplab_ide/mplab_ide/modules/../../bin/
 # Adding MPLAB X bin directory to path.
-PATH:=C:/Program Files (x86)/Microchip/MPLABX/mplab_ide/mplab_ide/modules/../../bin/:$(PATH)
+PATH:=C:/Program Files (x86)/Microchip/MPLABX/v3.30/mplab_ide/mplab_ide/modules/../../bin/:$(PATH)
 # Path to java used to run MPLAB X when this makefile was created
-MP_JAVA_PATH="C:\Program Files (x86)\Microchip\MPLABX\sys\java\jre1.6.0_32-windows-x64\java-windows/bin/"
+MP_JAVA_PATH="C:\Program Files (x86)\Microchip\MPLABX\v3.30\sys\java\jre1.8.0_65/bin/"
 OS_CURRENT="$(shell uname -s)"
-MP_CC="C:\Program Files (x86)\Microchip\xc16\v1.10\bin\xc16-gcc.exe"
+MP_CC="C:\Program Files (x86)\Microchip\xc16\v1.26\bin\xc16-gcc.exe"
 # MP_CPPC is not defined
 # MP_BC is not defined
-# MP_AS is not defined
-# MP_LD is not defined
-MP_AR="C:\Program Files (x86)\Microchip\xc16\v1.10\bin\xc16-ar.exe"
-DEP_GEN=${MP_JAVA_PATH}java -jar "C:/Program Files (x86)/Microchip/MPLABX/mplab_ide/mplab_ide/modules/../../bin/extractobjectdependencies.jar" 
-MP_CC_DIR="C:\Program Files (x86)\Microchip\xc16\v1.10\bin"
+MP_AS="C:\Program Files (x86)\Microchip\xc16\v1.26\bin\xc16-as.exe"
+MP_LD="C:\Program Files (x86)\Microchip\xc16\v1.26\bin\xc16-ld.exe"
+MP_AR="C:\Program Files (x86)\Microchip\xc16\v1.26\bin\xc16-ar.exe"
+DEP_GEN=${MP_JAVA_PATH}java -jar "C:/Program Files (x86)/Microchip/MPLABX/v3.30/mplab_ide/mplab_ide/modules/../../bin/extractobjectdependencies.jar"
+MP_CC_DIR="C:\Program Files (x86)\Microchip\xc16\v1.26\bin"
 # MP_CPPC_DIR is not defined
 # MP_BC_DIR is not defined
-# MP_AS_DIR is not defined
-# MP_LD_DIR is not defined
-MP_AR_DIR="C:\Program Files (x86)\Microchip\xc16\v1.10\bin"
+MP_AS_DIR="C:\Program Files (x86)\Microchip\xc16\v1.26\bin"
+MP_LD_DIR="C:\Program Files (x86)\Microchip\xc16\v1.26\bin"
+MP_AR_DIR="C:\Program Files (x86)\Microchip\xc16\v1.26\bin"
 # MP_BC_DIR is not defined

--- a/Autopilot/Relay/nbproject/configurations.xml
+++ b/Autopilot/Relay/nbproject/configurations.xml
@@ -30,7 +30,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.10</languageToolchainVersion>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
         <platform>3</platform>
       </toolsSet>
       <compileType>
@@ -38,8 +38,11 @@
           <linkerLibItems>
           </linkerLibItems>
         </linkerTool>
+        <archiverTool>
+        </archiverTool>
         <loading>
           <useAlternateLoadableFile>false</useAlternateLoadableFile>
+          <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
       </compileType>
@@ -91,8 +94,6 @@
         <property key="use-cci" value="false"/>
         <property key="use-iar" value="false"/>
       </C30>
-      <C30-AS>
-      </C30-AS>
       <C30-LD>
         <property key="additional-options-use-response-files" value="false"/>
         <property key="boot-eeprom" value="no_eeprom"/>


### PR DESCRIPTION
**Changes**:
- Tested RSSI implementation of receiver. PWM range in ticks for RSSI (Ch7) is between  657 - 1195 (1.0ms to 1.8 ms). PWM range for Signal Quality (Ch6) is  652  to 1208 (1ms to 2ms)
- Found out issue where in the attitude manager initialization, input channel 7 was being set as an output, thus disabling PWM input readings for the channel. According to @chrishajduk84  this was used for DMA functionality (for restarting chips and what not). Not sure if disabling this will have negative consecquences, and must be investigated further when improving/refactoring the DMA code. For now we'll enable channel 7 for RSSI
- Added option for ground station downlink to display non-scaled PWM values, useful for calibrating the PWM values
