### PR TITLE
Channel Disconnect detection on every channel

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -110,7 +110,6 @@ int input_RC_YawRate = 0;
 int input_RC_Aux1 = 0; //0=Roll, 1= Pitch, 2=Yaw
 int input_RC_Aux2 = 0; //0 = Saved Value, 1 = Edit Mode
 int input_RC_Switch1 = 0;
-int input_RC_UHFSwitch = 0;
 
 //Ground Station Input Signals
 int input_GS_Roll = 0;
@@ -385,11 +384,10 @@ void setHeadingSetpoint(int setpoint){
 
 void inputCapture(){
     int* channelIn;
-    channelIn = getPWMArray();
+    channelIn = getPWMArray(getTime());
     inputMixing(channelIn, &input_RC_RollRate, &input_RC_PitchRate, &input_RC_Throttle, &input_RC_YawRate, &input_RC_Flap);
 
     // Switches and Knobs
-    input_RC_UHFSwitch = channelIn[UHF_STATUS_IN_CHANNEL - 1];
 //        sp_Type = channelIn[5];
 //        sp_Value = channelIn[6];
     input_RC_Switch1 = channelIn[AUTOPILOT_ACTIVE_IN_CHANNEL - 1];
@@ -977,9 +975,9 @@ int writeDatalink(p_priority packet){
             statusData->data.p2_block.batteryLevel2 = batteryLevel2;
 //            debug("SW3");
             if (show_scaled_pwm){
-                input = getPWMArray();
+                input = getPWMArray(getTime());
             } else {
-                input = (int*)getICValues();
+                input = (int*)getICValues(getTime());
             }
             statusData->data.p2_block.ch1In = input[0];
             statusData->data.p2_block.ch2In = input[1];
@@ -1055,7 +1053,7 @@ int writeDatalink(p_priority packet){
 void checkUHFStatus(){
     unsigned long int time = getTime();
     
-    if (!isPWMAlive(time)){
+    if (getPWMInputStatus() == PWM_STATUS_UHF_LOST){
         if (UHFTimer == 0){ //0 indicates that this is the first time we lost UHF
             UHFTimer = time;
             setProgramStatus(KILL_MODE_WARNING);

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -35,7 +35,7 @@ static unsigned long int last_capture_time[8];
  */
 unsigned int* getICValues(unsigned int sys_time)
 {
-    char channel;
+    int channel;
     for (channel = 0; channel < 8; channel++) {
         /*
          * Check if we received any data from the channel within the threshold.

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -33,7 +33,7 @@ static unsigned long int last_capture_time[8];
 /**
  * Calculate and update the input values
  */
-unsigned int* getICValues(unsigned int sys_time)
+unsigned int* getICValues(unsigned long int sys_time)
 {
     int channel;
     for (channel = 0; channel < 8; channel++) {
@@ -57,7 +57,6 @@ unsigned int* getICValues(unsigned int sys_time)
                      */
                     capture_value[channel] = ((PR2 - start_time[channel]) + end_time[channel]);
                 }
-
                 new_data_available[channel] = 0;
             }
         }

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -16,34 +16,25 @@
 #ifndef INPUTCAPTURE_H
 #define	INPUTCAPTURE_H
 
-#include "main.h"
+/**
+ * Number of ms after the last detected edge on a channel before it can be assumed to be
+ * disconnected
+ */
+#define PWM_ALIVE_THRESHOLD 100
 
 /**
  * Initializes capture configuration of the PWM input channels. Make sure to initialize Timer2
  * before calling this!
- * @param initIC An 8-bit bitmask specifying which channels to enable (will enable interrupts on these)
+ * @param initIC An 8-bit bit mask specifying which channels to enable (will enable interrupts on these)
  */
 void initIC(char initIC);
 
 /**
  * Gets the input capture value (in ticks) of all the channels
+ * @param sys_time The system time in milliseconds. Used for detecting disconnected channels. A channel
+ * that is disconnected will have a value of 0.
  * @return Array containing all the channel values
  */
-unsigned int* getICValues();
-
-/**
- * Gets the input capture value of a specific value
- * @param channel number from 0-7
- * @return Value of the IC channel. This is in Timer2 ticks, not ms! 
- * The timer module defines number of ticks in a ms
- */
-unsigned int getICValue(unsigned char channel);
-
-/**
- * Get the last system time an edge was detected on channel 7. Should be used
- * for detecting a UHF disconnect
- * @return System time in ms since the last detected edge/data on channel 7
- */
-unsigned long int getICLastCapturedTime(void);
+unsigned int* getICValues(unsigned int sys_time);
 
 #endif

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -27,7 +27,7 @@
  * before calling this!
  * @param initIC An 8-bit bit mask specifying which channels to enable (will enable interrupts on these)
  */
-void initIC(char initIC);
+void initIC(unsigned char initIC);
 
 /**
  * Gets the input capture value (in ticks) of all the channels

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -35,6 +35,6 @@ void initIC(unsigned char initIC);
  * that is disconnected will have a value of 0.
  * @return Array containing all the channel values
  */
-unsigned int* getICValues(unsigned int sys_time);
+unsigned int* getICValues(unsigned long int sys_time);
 
 #endif

--- a/Autopilot/AttitudeManager/PWM.c
+++ b/Autopilot/AttitudeManager/PWM.c
@@ -31,6 +31,16 @@ static int pwm_inputs[NUM_CHANNELS];
 static int pwm_outputs[NUM_CHANNELS]; //The output for status updates
 
 /**
+ * Used to keep track of the connected/disconnected input channels
+ */
+static unsigned char disconnected_pwm_inputs;
+
+/**
+ * Used so that we dont mark disabled channels as disconnected
+ */
+static unsigned char enabled_input_channels;
+
+/**
  * Scale factors and offsets for each of the 8 channels
  */
 static float input_scale_factors[NUM_CHANNELS];
@@ -40,14 +50,17 @@ static int output_offsets[NUM_CHANNELS];
 
 static void calculatePWM(void);
 
-void initPWM(char inputChannels, char outputChannels){
+void initPWM(unsigned char inputChannels, unsigned char outputChannels)
+{
     initTimer2();
     initIC(inputChannels);
     initOC(outputChannels);
-    
-     //Set the initial offsets and scaling factors
+
+    enabled_input_channels = inputChannels;
+
+    //Set the initial offsets and scaling factors
     int i = 0;
-    for (i = 0; i < NUM_CHANNELS; i++){
+    for (i = 0; i < NUM_CHANNELS; i++) {
         input_scale_factors[i] = DEFAULT_INPUT_SCALE_FACTOR;
         output_scale_factors[i] = DEFAULT_OUTPUT_SCALE_FACTOR;
         output_offsets[i] = MIDDLE_PWM;
@@ -55,50 +68,56 @@ void initPWM(char inputChannels, char outputChannels){
     }
 }
 
-int* getPWMArray(){
-    calculatePWM();
+int* getPWMArray(unsigned int sys_time)
+{
+    char channel_enabled;
+    unsigned int* ic_values = getICValues(sys_time);
+    int channel = 0;
+    for (channel = 0; channel < NUM_CHANNELS; channel++) {
+        channel_enabled = enabled_input_channels & (1 << channel);
+
+        //if the channel disconnected
+        if (ic_values[channel] == 0 && !channel_enabled) {
+            pwm_inputs[channel] = DISCONNECTED_PWM_VALUE;
+            disconnected_pwm_inputs = disconnected_pwm_inputs | (1 << channel);
+        } else { //otherwise calculate as usual
+            pwm_inputs[channel] = (int) ((ic_values[channel] - input_offsets[channel]) * input_scale_factors[channel]);
+            disconnected_pwm_inputs = disconnected_pwm_inputs & (~(1 << channel)); //set the bit as 0
+        }
+    }
     return pwm_inputs;
 }
 
-void setPWM(unsigned int channel, int pwm){
-    if (channel > 0 && channel <= NUM_CHANNELS && pwm >= MIN_PWM && pwm <= MAX_PWM){
+void setPWM(unsigned int channel, int pwm)
+{
+    if (channel > 0 && channel <= NUM_CHANNELS && pwm >= MIN_PWM && pwm <= MAX_PWM) {
         pwm_outputs[channel - 1] = pwm;
-        setOCValue(channel - 1, (int)(pwm * output_scale_factors[channel - 1] + output_offsets[channel - 1]));
+        setOCValue(channel - 1, (int) (pwm * output_scale_factors[channel - 1] + output_offsets[channel - 1]));
     }
 }
 
-int* getPWMOutputs(){
+int* getPWMOutputs()
+{
     return pwm_outputs;
 }
 
-char isPWMAlive(unsigned long int sys_time){
-    if ((sys_time - getICLastCapturedTime()) <= PWM_ALIVE_THRESHOLD){
-        return 1;
-    }
-    return 0;
+unsigned char getPWMInputStatus(void)
+{
+    return disconnected_pwm_inputs;
 }
 
-void calibratePWMInputs(unsigned int channel, float signalScaleFactor, unsigned int signalOffset){
-    if (channel > 0 && channel <= NUM_CHANNELS){ //Check if channel number is valid
+void calibratePWMInputs(unsigned int channel, float signalScaleFactor, unsigned int signalOffset)
+{
+    if (channel > 0 && channel <= NUM_CHANNELS) { //Check if channel number is valid
         input_scale_factors[channel - 1] = signalScaleFactor;
         input_offsets[channel - 1] = signalOffset;
     }
 }
 
-void calibratePWMOutputs(unsigned int channel, float signalScaleFactor, unsigned int signalOffset){
-    if (channel > 0 && channel <= NUM_CHANNELS){ //Check if channel number is valid
+void calibratePWMOutputs(unsigned int channel, float signalScaleFactor, unsigned int signalOffset)
+{
+    if (channel > 0 && channel <= NUM_CHANNELS) { //Check if channel number is valid
         output_scale_factors[channel - 1] = signalScaleFactor;
         output_offsets[channel - 1] = signalOffset;
-    }
-}
-
-/**
- * Calculates/scales the input capture value of every channel to the PWM range
- */
-static void calculatePWM(void){
-    unsigned int* ic_values = getICValues();
-    int channel = 0;
-    for (channel = 0; channel < NUM_CHANNELS; channel++){
-        pwm_inputs[channel] = (int)((ic_values[channel] - input_offsets[channel]) * input_scale_factors[channel]);
     }
 }

--- a/Autopilot/AttitudeManager/PWM.c
+++ b/Autopilot/AttitudeManager/PWM.c
@@ -5,6 +5,7 @@
 #include "PWM.h"
 #include "OutputCompare.h"
 #include "InputCapture.h"
+#include "timer.h"
 
 /**
  * The middle of the PWM range of the RC controller. This is used as the initial
@@ -47,8 +48,6 @@ static float input_scale_factors[NUM_CHANNELS];
 static int input_offsets[NUM_CHANNELS];
 static float output_scale_factors[NUM_CHANNELS];
 static int output_offsets[NUM_CHANNELS];
-
-static void calculatePWM(void);
 
 void initPWM(unsigned char inputChannels, unsigned char outputChannels)
 {

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -72,7 +72,7 @@ void initPWM(unsigned char inputChannels,unsigned char outputChannels);
  * @return An integer array of size 8 containing the PWM values for all the channels. Note that
  * this array is zero-indexed, so channel 1 is index 0 (unlike the getPWM function)
  */
-int* getPWMArray(unsigned int sys_time);
+int* getPWMArray(unsigned long int sys_time);
 
 /**
  * Sets the PWM output of a particular output. Make sure initPWM is called before

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -45,25 +45,34 @@
 #define HALF_PWM_RANGE (MAX_PWM - MIN_PWM)/2
 
 /**
- * Number of ms after the last detected edge on channel 7 that it can be assumed
- * the UHF connection is lost/PWM dead
+ * Value to give to a channel thats disconnected. Used to easily let the
+ * ground station operator know that the input is disconnected, and so that you don't
+ * get random PWM input values if you have specific scaling
+ * factors and offsets set for a particular channel
  */
-#define PWM_ALIVE_THRESHOLD 100
+#define DISCONNECTED_PWM_VALUE -10000
+
+/**
+ * Shortcuts for the applicable PWM statuses
+ */
+#define PWM_STATUS_UHF_LOST 0xFF
+#define PWM_STATUS_OK 0
 
 /**
  * Initializes the PWM input and output channels. Also initializes Timer2
  * @param inputChannels 8-bit bit mask indicating which inputs to initialize (probably want to send 0xFF for all)
  * @param outputChannels 8-bit bit mask indicating which outputs to initialize
  */
-void initPWM(char inputChannels, char outputChannels);
+void initPWM(unsigned char inputChannels,unsigned char outputChannels);
 
 /**
  * Gets the scaled PWM values in the range of MIN_PWM and MAX_PWM from all the channels.
  * Make sure that initPWM is called before calling this, otherwise the results will be useless
+ * @param sys_time System time in ms used for detecting disconnects
  * @return An integer array of size 8 containing the PWM values for all the channels. Note that
  * this array is zero-indexed, so channel 1 is index 0 (unlike the getPWM function)
  */
-int* getPWMArray();
+int* getPWMArray(unsigned int sys_time);
 
 /**
  * Sets the PWM output of a particular output. Make sure initPWM is called before
@@ -83,11 +92,14 @@ void setPWM(unsigned int channel, int pwm);
 int* getPWMOutputs();
 
 /**
- * Checks PWM based on last data received on channel 7
- * @param sys_time The current system time in ms
- * @return 1 if the UHF connection is still alive, otherwise returns 0
+ * Returns 8-bit bit mask indicating the status of each channel. A 0 means that the channel
+ * is functioning (connected or disabled), whilst a 1 means a channel is disconnected
+ * (only if its enabled). Therefore if the status is equal to 0, you can assume all
+ * the channels are working fine. If its greater than 0, some of the channels have disconnected.
+ * Most importantly, if the status equals 0xFF, all the channels have disconnected,
+ * which indicates that the UHF connection was lost.
  */
-char isPWMAlive(unsigned long int sys_time);
+unsigned char getPWMInputStatus(void);
 
 /**
  * Calibrates the input range and trim of a PWM channel input


### PR DESCRIPTION
**Changes**:
- Added disconnect detection for all the channels, instead of channel 7. This is to let the ground station operator know if something disconnected. Also lets the autopilot know, if say, the Autopilot on/off switch disconnected, throttle input disconnected. This way, the autopilot can take over if the autonomous level is set to manual but a channel disconnect was discovered, etc.

 - Removed some old legacy uhf code from attitude manager (input_RC_UHFSwitch) etc.

The underlying basis for this implementation is that in the ISR for each channel, on an edge fall we save the a timestamp representing the last captured time for the channel. Then when we perform the calculations, we require the user to pass in the system time, to which we compare it. If its more than the configurable threshold of 100ms (so we lost connection for 100ms on the channel) we'll set the input as 0. This is in inputCompare.c

In PWM.c, if we detect a 0, and the channel was set as enabled, we'll mark it down in our own bitmask, which we can send to the ground station to let it know which channel was disconnected.

**Note** I still need to test this. Will do so tomorrow's work day

**Note 2** The reasoning behind this implementation is if a single channel is initially connected and then disconnected, we have no way of knowing it, since the variables will store the last state if an ISR doesnt trigger. This gives us more debug capabilities.

A future PR will add the channel status header packet to the datalink.