### PR TITLE
Receiver PPM Implementation

### DIFF
--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -114,9 +114,9 @@ unsigned int* getICValues(unsigned long int sys_time)
  */
 void initIC(unsigned char initIC)
 {
-    //If using PPM, we want to unconditionally turn on channel 1
+    //If using PPM, we want to unconditionally turn on channel 7
     #if USE_PPM
-      initIC = 1;
+      initIC = 0b01000000;
       ppm_index = 0;
     #endif
 
@@ -207,14 +207,14 @@ void initIC(unsigned char initIC)
 * and last fall time to determine if a PPM sync occured, used to keep track
 * of the positions of the channels
 */
-void __attribute__((__interrupt__, no_auto_psv)) _IC1Interrupt(void)
+void __attribute__((__interrupt__, no_auto_psv)) _IC7Interrupt(void)
 {
     static unsigned int time_diff;
     
-    if (PORTDbits.RD8 == !PPM_INVERTED) { //If PPM inverted, check for fall (0). Otherwise check for rise (1)
-        start_time[ppm_index] = IC1BUF;
+    if (PORTDbits.RD14 == !PPM_INVERTED) { //If PPM inverted, check for fall (0). Otherwise check for rise (1)
+        start_time[ppm_index] = IC7BUF;
     } else { //if PPM inverted, then if rise (1). Otherwise if fall
-        end_time[ppm_index] = IC1BUF;
+        end_time[ppm_index] = IC7BUF;
         
         //take into account for timer overflow
         if (end_time[ppm_index] > start_time[ppm_index]){

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -9,6 +9,12 @@
 #include "timer.h"
 
 /**
+* Number of ticks that indicate a sync pulse
+* -50 ticks for a little tolerance
+*/
+#define PPM_SYNC_TICKS (int)(PPM_SYNC_TIME*T2_TICKS_TO_MSEC/1000) - 50
+
+/**
  * Holds the capture start and end time so that we can compare them later
  */
 static unsigned int start_time[8];
@@ -31,8 +37,10 @@ static unsigned int capture_value[8];
 static unsigned long int last_capture_time[8];
 
 /**
- * Calculate and update the input values
+ * Used to keep track of the pulse position when PPM is enabled
  */
+static unsigned char ppm_index;
+
 unsigned int* getICValues(unsigned long int sys_time)
 {
     int channel;
@@ -71,16 +79,22 @@ unsigned int* getICValues(unsigned long int sys_time)
  * @param initIC An 8-bit bit mask specifying which channels to enable interrupts on
  */
 void initIC(unsigned char initIC)
-{   
+{
+    //If using PPM, we want to unconditionaly turn on channel 1
+    #if USE_PPM
+      initIC = 1;
+      ppm_index = 0;
+    #endif
+
     if (initIC & 0b01) {
         IC1CONbits.ICM = 0b00; // Disable Input Capture 1 module (required to change it)
         IC1CONbits.ICTMR = 1; // Select Timer2 as the IC1 Time base
-        
+
         /**
          * Generate capture event on every Rising and Falling edge
          * Note that the ICI register is ignored when ICM is in edge detection mode (001)
          */
-        IC1CONbits.ICM = 0b001; 
+        IC1CONbits.ICM = 0b001;
 
         // Enable Capture Interrupt And Timer2
         IPC0bits.IC1IP = 7; // Setup IC1 interrupt priority level - Highest
@@ -152,11 +166,59 @@ void initIC(unsigned char initIC)
     }
 }
 
+#if USE_PPM
 /**
- * Below are the configured interrupt handler functions for when there is an edge
- * change on an enabled PWM channel. These functions will mark the new_data_available
+* PPM Interrupt Service routine for Channel 1 for when PPM is enabled. Will trigger
+* on any edge change on channel 1. Calculates the time between the last rise time
+* and last fall time to determine if a PPM sync occured, used to keep track
+* of the positions of the channels
+*/
+void __attribute__((__interrupt__, no_auto_psv)) _IC1Interrupt(void)
+{
+    unsigned char last_fall_ppm_index = ppm_index -1;
+    if (last_fall_ppm_index > PPM_CHANNELS){ //handle potential overflow
+        last_fall_ppm_index = PPM_CHANNELS - 1;
+    }
+    if (PORTDbits.RD8 == 1) { // if IC signal is goes 0 --> 1
+        start_time[ppm_index] = IC1BUF;
+        new_data_available[ppm_index] = 0; //we should do this so that we don't parse partial values (with wrong start time)
+
+        if (start_time[ppm_index] > end_time[last_fall_ppm_index]){
+          if (start_time[ppm_index] - end_time[last_fall_ppm_index] >= PPM_SYNC_TICKS){
+            ppm_index = 0;
+          }
+        } else {
+          if (((PR2 - end_time[last_fall_ppm_index]) + start_time[ppm_index]) >= PPM_SYNC_TICKS){
+            ppm_index = 0;
+          }
+        }
+    } else {
+        end_time[ppm_index] = IC1BUF;
+        new_data_available[ppm_index] = 1;
+
+        last_capture_time[ppm_index] = getTime();
+        ppm_index = (ppm_index + 1) % PPM_CHANNELS; // modulo to prevent overflow
+    }
+
+    /**
+     * Clear the input compare buffer to avoid any issues when hot swapping PWM cables.
+     * Without this, when hot-swapping PWM connections, you may get weird values (in the 10000's range)
+     * when reading off of the connection. Note that in normal circumstances, the maximum size
+     * of the buffer at any time will be 1, so this while loop should never execute. Its only when
+     * you disconnect it and reconnect it that stuff gets weird.
+     */
+    while (IC1CONbits.ICBNE) { //while the ic buffer not empty flag is set
+        IC1BUF; //read a value from the 4-size FIFO buffer
+    }
+    IFS0bits.IC1IF = 0; //reset the interrupt flag
+}
+#else
+
+/**
+ * PWM Interrupt Service Routines for when PPM is disabled. These will trigger
+ * on an edge change on an enabled PWM channel.These functions will mark the new_data_available
  * bits, as well as set/save the appropriate timer values.
- * 
+ *
  * If a high value is detected on an interrupt, it means we went from 0->1, so we mark
  * the start time. Otherwise, we mark the end time. In the latter case, we'll also mark
  * the data available bit as either 1 or 0. If we went from 0->1, we'll mark the data as not
@@ -174,7 +236,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC1Interrupt(void)
         new_data_available[0] = 1;
         last_capture_time[0] = getTime();
     }
-    
+
     /**
      * Clear the input compare buffer to avoid any issues when hot swapping PWM cables.
      * Without this, when hot-swapping PWM connections, you may get weird values (in the 10000's range)
@@ -200,7 +262,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC2Interrupt(void)
         new_data_available[1] = 1;
         last_capture_time[1] = getTime();
     }
-    
+
     while (IC2CONbits.ICBNE) {
         IC2BUF;
     }
@@ -219,7 +281,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC3Interrupt(void)
         new_data_available[2] = 1;
         last_capture_time[2] = getTime();
     }
-    
+
     while (IC3CONbits.ICBNE) {
         IC3BUF;
     }
@@ -238,7 +300,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC4Interrupt(void)
         new_data_available[3] = 1;
         last_capture_time[3] = getTime();
     }
-    
+
     while (IC4CONbits.ICBNE) {
         IC4BUF;
     }
@@ -257,7 +319,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC5Interrupt(void)
         new_data_available[4] = 1;
         last_capture_time[4] = getTime();
     }
-    
+
     while (IC5CONbits.ICBNE) {
         IC5BUF;
     }
@@ -276,7 +338,7 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC6Interrupt(void)
         new_data_available[5] = 1;
         last_capture_time[5] = getTime();
     }
-    
+
     while (IC6CONbits.ICBNE) {
         IC6BUF;
     }
@@ -320,3 +382,4 @@ void __attribute__((__interrupt__, no_auto_psv)) _IC8Interrupt(void)
     }
     IFS1bits.IC8IF = 0;
 }
+#endif

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -5,7 +5,6 @@
 
 #include <p33Fxxxx.h>
 #include "InputCapture.h"
-#include "OutputCompare.h"
 #include "timer.h"
 
 /**

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -15,10 +15,16 @@
 
 
 /**
- * Holds the capture start and end time so that we can compare them later
+ * Holds the capture start and end time so that we can compare them later. We can
+ * only do 8 with PWM enabled. Otherwise
  */
+#if USE_PPM
+static unsigned int start_time[PPM_CHANNELS];
+static unsigned int end_time[PPM_CHANNELS];
+#else
 static unsigned int start_time[8];
 static unsigned int end_time[8];
+#endif
 
 /**
  * Interrupt flag for if new data is available and ready to read. This variable
@@ -31,7 +37,11 @@ static char new_data_available[8];
 /**
  * The actual time between interrupts (in timer2 ticks, not ms)
  */
+#if USE_PPM
+static unsigned int capture_value[PPM_CHANNELS];
+#else
 static unsigned int capture_value[8];
+#endif
 
 /**
  * Last capture time in ms for all the channels. Used for detecting a channel/pwm

--- a/Autopilot/AttitudeManager/InputCapture.c
+++ b/Autopilot/AttitudeManager/InputCapture.c
@@ -12,7 +12,6 @@
  */
 #define PPM_SYNC_TICKS (int)((float)(PPM_MIN_SYNC_TIME/1000)*T2_TICKS_TO_MSEC)
 
-
 /**
  * Holds the capture start and end time so that we can compare them later. We can
  * only do 8 with PWM enabled. Otherwise

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -23,10 +23,10 @@
 #define USE_PPM 1
 
 /**
-* If using PPM, this is the sync time between frames in ms. Required so that
-* the picpilot can tell frames apart
-*/
-#define PPM_SYNC_TIME 3000
+ * If the PPM signal is inverted. Some receivers, such as the ezUHF have an inverted
+ * PPM signal, so set this to 1. If using the OrangeRX, set this to 0
+ */
+#define PPM_INVERTED 0
 
 /**
 * How many channels are expected to be in a single PPM frame. Cant be more than 8
@@ -34,16 +34,13 @@
 #define PPM_CHANNELS 8
 
 /**
-* If using PPM, this is the sync time between frames in ms. Required so that
-* the pic pilot can tell frames apart
-*/
-#define PPM_SYNC_TIME 3000
+ * If using PPM, this is the sync time between frames in us. Required so that
+ * the pic pilot can tell frames apart. A value of 3000us is recommended. Note
+ * that this is the minimum sync time. It may/will be larger, especially if using
+ * less than 12 PPM channels
+ */
+#define PPM_MIN_SYNC_TIME 3000
 
-/**
-* How many channels are expected to be in a single PPM frame
-*/
-#define PPM_CHANNELS 8
-        
 /**
  * Number of ms after the last detected edge on a channel before it can be assumed to be
  * disconnected

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -6,11 +6,7 @@
  * capabilities of the chip. In essence, it lets you get the raw, uncalibrated PWM values
  * from the 8 available input compare channels
  *
- * Channel 7 is specifically also configured as the UHF connection switch. An edge
- * detected on channel 7 will signify that the UHF is still alive by saving a timestamp
- * which can be compared later. This can be reconfigured to a different channel, however
- * the position of the timestamp save must be placed in a different interrupt service
- * routine.
+ * If using PPM, by default the input channel on the Picpilot will be channel 7.
  */
 
 #ifndef INPUTCAPTURE_H

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -3,9 +3,9 @@
  * @author Chris Hajduk
  * @created March 4, 2013, 10:31 PM
  * @description This file provides the methods necessary to access the input capture
- * capabilities of the chip. In essence, it lets you get the raw, uncalibrated PWM values 
+ * capabilities of the chip. In essence, it lets you get the raw, uncalibrated PWM values
  * from the 8 available input compare channels
- * 
+ *
  * Channel 7 is specifically also configured as the UHF connection switch. An edge
  * detected on channel 7 will signify that the UHF is still alive by saving a timestamp
  * which can be compared later. This can be reconfigured to a different channel, however
@@ -17,6 +17,23 @@
 #define	INPUTCAPTURE_H
 
 /**
+* Use this setting to disable or enable PPM. PPM is currently only configured
+* for channel 1. If disabled, regular PWM via the 8 channel inputs is used
+*/
+#define USE_PPM 1
+
+/**
+* If using PPM, this is the sync time between frames in ms. Required so that
+* the pic pilot can tell frames apart
+*/
+#define PPM_SYNC_TIME 3000
+
+/**
+* How many channels are expected to be in a single PPM frame
+*/
+#define PPM_CHANNELS 8
+        
+/**
  * Number of ms after the last detected edge on a channel before it can be assumed to be
  * disconnected
  */
@@ -24,13 +41,12 @@
 
 /**
  * Initializes capture configuration of the PWM input channels. Make sure to initialize Timer2
- * before calling this!
- * @param initIC An 8-bit bit mask specifying which channels to enable (will enable interrupts on these)
+ * before calling this! Disabled channels will not have interrupts called on them
  */
 void initIC(unsigned char initIC);
 
 /**
- * Gets the input capture value (in ticks) of all the channels
+ * Gets the input capture value (in Timer2 ticks) of all the channels
  * @param sys_time The system time in milliseconds. Used for detecting disconnected channels. A channel
  * that is disconnected will have a value of 0.
  * @return Array containing all the channel values

--- a/Autopilot/AttitudeManager/InputCapture.h
+++ b/Autopilot/AttitudeManager/InputCapture.h
@@ -29,7 +29,7 @@
 #define PPM_INVERTED 0
 
 /**
-* How many channels are expected to be in a single PPM frame. Cant be more than 8
+* How many channels are expected to be in a single PPM frame
 */
 #define PPM_CHANNELS 8
 

--- a/Autopilot/Common/debug.c
+++ b/Autopilot/Common/debug.c
@@ -29,7 +29,8 @@ void error(char* message){
     for (i = 0; i < mLength; i++){
         errorMessage[i + ERROR_TAG_STRING_LENGTH] = message[i];
     }
-    errorMessage[i + ERROR_TAG_STRING_LENGTH] = '\0';
+    errorMessage[i + ERROR_TAG_STRING_LENGTH] = '\r';
+    errorMessage[i + ERROR_TAG_STRING_LENGTH + 1] = '\0';
     UART1_SendString(errorMessage);
 }
 
@@ -53,7 +54,8 @@ void warning(char* message){
     for (i = 0; i < mLength; i++){
         warningMessage[i + WARNING_TAG_STRING_LENGTH] = message[i];
     }
-    warningMessage[i + ERROR_TAG_STRING_LENGTH] = '\0';
+    warningMessage[i + WARNING_TAG_STRING_LENGTH] = '\r';
+    warningMessage[i + WARNING_TAG_STRING_LENGTH + 1] = '\0';
     UART1_SendString(warningMessage);
 }
 
@@ -77,6 +79,7 @@ void debug(char* message){
     for (i = 0; i < mLength; i++){
         debugMessage[i + DEBUG_TAG_STRING_LENGTH] = message[i];
     }
-    debugMessage[i + ERROR_TAG_STRING_LENGTH] = '\0';
+    debugMessage[i + DEBUG_TAG_STRING_LENGTH] = '\r';
+    debugMessage[i + DEBUG_TAG_STRING_LENGTH + 1] = '\0';
     UART1_SendString(debugMessage);
 }


### PR DESCRIPTION
**Changes**:
- Receiver input of up to 16 channels using PPM on channel 1
- debug functions now also output a carriage return (so you dont have to keep reconfiguring realterm or putty)

Tested on both the OrangeRX and ezUHF. Note that the ezUHF has an inverted PPM output, thus an option for it was also added. Both the receivers were configured to output ppm on channel 5/port 5 output. 

Both were also configured to output link quality on channel 6 and rssi on channel 7.

Also note that the ezUHF doesnt have the option to disable its PPM/PWM channels as a fail safe, thus channel detection cant be used for it. The dragon link does, so i figure its not worth implementing an alternative method of doing this, since we'll probably end up using the dragon link on the plane and the orangerx on the quad.

The way I imlemented it, you can either use PPM or you can use PWM, but not both. It is however possible to do so, although the channel mapping will get complicated. Since we have no need for this right now, no need to implement it yet.

Also if switching between PPM or PWM, the input capture ranges have to be recalibrated. From my testing, the pulse-widths with PPM were shorter than PWM (depending on the receiver)

Other links:
https://uwarg-docs.atlassian.net/wiki/display/PicPilot/OrangeRX+433Mhz+OpenLRSng+UHF+System
https://uwarg-docs.atlassian.net/wiki/display/PicPilot/ezUHF+433Mhz+Radio+System