### PR TITLE
Fixed parsing uplinks & added xbee and uhf rssi statistics to downlink

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -516,6 +516,12 @@ uint8_t getControlValue(CtrlType type) {
 
 void readDatalink(void){
     struct DatalinkCommand* cmd = popDatalinkCommand();
+    uint8_t cmd_data[88];
+    
+    //this step is necessary for correct parsing of data, as we can't cast
+    //unaligned data to multi-byte values.
+    memcpy(cmd_data, cmd->data, cmd->data_length);
+    
     //TODO: Add rudimentary input validation
     if ( cmd ) {
         if (lastCommandSentCode[lastCommandCounter]/100 == cmd->cmd){
@@ -533,49 +539,49 @@ void readDatalink(void){
 #endif
                 break;
             case SET_PITCH_KD_GAIN:
-                setGain(PITCH_RATE, KD, *(float*)(&cmd->data));
+                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ROLL_KD_GAIN:
-                setGain(ROLL_RATE, KD, *(float*)(&cmd->data));
+                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_YAW_KD_GAIN:
-                setGain(YAW_RATE, KD, *(float*)(&cmd->data));
+                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_PITCH_KP_GAIN:
-                setGain(PITCH_RATE, KP, *(float*)(&cmd->data));
+                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ROLL_KP_GAIN:
-                setGain(ROLL_RATE, KP, *(float*)(&cmd->data));
+                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_YAW_KP_GAIN:
-                setGain(YAW_RATE, KP, *(float*)(&cmd->data));
+                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_PITCH_KI_GAIN:
-                setGain(PITCH_RATE, KI, *(float*)(&cmd->data));
+                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ROLL_KI_GAIN:
-                setGain(ROLL_RATE, KI, *(float*)(&cmd->data));
+                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_YAW_KI_GAIN:
-                setGain(YAW_RATE, KI, *(float*)(&cmd->data));
+                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_HEADING_KD_GAIN:
-                setGain(HEADING, KD, *(float*)(&cmd->data));
+                setGain(HEADING, KD, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_HEADING_KP_GAIN:
-                setGain(HEADING, KP, *(float*)(&cmd->data));
+                setGain(HEADING, KP, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_HEADING_KI_GAIN:
-                setGain(HEADING, KI, *(float*)(&cmd->data));
+                setGain(HEADING, KI, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ALTITUDE_KD_GAIN:
-                setGain(ALTITUDE, KD, *(float*)(&cmd->data));
+                setGain(ALTITUDE, KD, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ALTITUDE_KP_GAIN:
-                setGain(ALTITUDE, KP, *(float*)(&cmd->data));
+                setGain(ALTITUDE, KP, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ALTITUDE_KI_GAIN:
-                setGain(ALTITUDE, KI, *(float*)(&cmd->data));
+                setGain(ALTITUDE, KI, CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_THROTTLE_KD_GAIN:
                 //setGain(THROTTLE, KD, *(float*)(&cmd->data));
@@ -588,89 +594,89 @@ void readDatalink(void){
                 break;
 
             case SET_PATH_GAIN:
-                amData.pathGain = *(float*)(&cmd->data);
+                amData.pathGain = CMD_TO_FLOAT(cmd_data);
                 amData.command = PM_SET_PATH_GAIN;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_ORBIT_GAIN:
-                amData.orbitGain = *(float*)(&cmd->data);
+                amData.orbitGain = CMD_TO_FLOAT(cmd_data);
                 amData.command = PM_SET_ORBIT_GAIN;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SHOW_GAIN:
-                displayGain = *(char*)(&cmd->data);
+                displayGain = *cmd_data;
                 break;
             case SET_PITCH_RATE:
-                input_GS_PitchRate = *(int*)(&cmd->data);
+                input_GS_PitchRate = CMD_TO_INT(cmd_data);
                 break;
             case SET_ROLL_RATE:
-                input_GS_RollRate = *(int*)(&cmd->data);
+                input_GS_RollRate = CMD_TO_INT(cmd_data);
                 break;
             case SET_YAW_RATE:
-                input_GS_YawRate = *(int*)(&cmd->data);
+                input_GS_YawRate = CMD_TO_INT(cmd_data);
                 break;
             case SET_PITCH_ANGLE:
-                input_GS_Pitch = *(int*)(&cmd->data);
+                input_GS_Pitch = CMD_TO_INT(cmd_data);
                 break;
             case SET_ROLL_ANGLE:
-                input_GS_Roll = *(int*)(&cmd->data);
+                input_GS_Roll = CMD_TO_INT(cmd_data);
                 break;
             case SET_YAW_ANGLE:
 //                sp_YawAngle = *(int*)(&cmd->data);
                 break;
             case SET_ALTITUDE:
-                input_GS_Altitude = *(int*)(&cmd->data);
+                input_GS_Altitude = CMD_TO_INT(cmd_data);
                 break;
             case SET_HEADING:
-                input_GS_Heading = *(int*)(&cmd->data);
+                input_GS_Heading = CMD_TO_INT(cmd_data);
                 break;
             case SET_THROTTLE:
-                input_GS_Throttle = *(int*)(&cmd->data);
+                input_GS_Throttle = CMD_TO_INT(cmd_data);
                 break;
             case SET_FLAP:
-                input_GS_Flap = *(int*)(&cmd->data);//(int)(((long int)(*(int*)(&cmd->data))) * MAX_PWM * 2 / 100) - MAX_PWM;
+                input_GS_Flap = CMD_TO_INT(cmd_data);//(int)(((long int)(*(int*)(&cmd->data))) * MAX_PWM * 2 / 100) - MAX_PWM;
                 break;
             case SET_AUTONOMOUS_LEVEL:
-                controlLevel = *(int*)(&cmd->data);
+                controlLevel = CMD_TO_INT(cmd_data);
                 forceGainUpdate();
                 break;
             case SET_ANGULAR_WALK_VARIANCE:
-                setAngularWalkVariance(*(float*)(&cmd->data));
+                setAngularWalkVariance(CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_GYRO_VARIANCE:
-                setGyroVariance(*(float*)(&cmd->data));
+                setGyroVariance(CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_MAGNETIC_VARIANCE:
-                setMagneticVariance(*(float*)(&cmd->data));
+                setMagneticVariance(CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_ACCEL_VARIANCE:
-                setAccelVariance(*(float*)(&cmd->data));
+                setAccelVariance(CMD_TO_FLOAT(cmd_data));
                 break;
             case SET_SCALE_FACTOR:
-                scaleFactor = *(float*)(&cmd->data);
+                scaleFactor = CMD_TO_FLOAT(cmd_data);
                 break;
             case CALIBRATE_ALTIMETER:
-                amData.calibrationHeight = *(float*)(&cmd->data);
+                amData.calibrationHeight = CMD_TO_FLOAT(cmd_data);
                 amData.command = PM_CALIBRATE_ALTIMETER;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case CLEAR_WAYPOINTS:
-                amData.waypoint.id = (*(char *)(&cmd->data)); //Dummy Data
+                amData.waypoint.id = *cmd_data; //Dummy Data
                 amData.command = PM_CLEAR_WAYPOINTS;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case REMOVE_WAYPOINT:
-                amData.waypoint.id = (*(char *)(&cmd->data));
+                amData.waypoint.id = *cmd_data;
                 amData.command = PM_REMOVE_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_TARGET_WAYPOINT:
-                amData.waypoint.id = *(char *)(&cmd->data);
+                amData.waypoint.id = *cmd_data;
                 amData.command = PM_SET_TARGET_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
@@ -690,24 +696,24 @@ void readDatalink(void){
                 queueRadioStatusPacket();
                 break;
             case KILL_PLANE:
-                if (*(int*)(&cmd->data) == 1234)
+                if (CMD_TO_INT(cmd_data) == 1234)
                     killPlane(TRUE);
                 break;
             case UNKILL_PLANE:
-                if (*(int*)(&cmd->data) == 1234)
+                if (CMD_TO_INT(cmd_data) == 1234)
                     killPlane(FALSE);
                 break;
             case ARM_VEHICLE:
-                if (*(int*)(&cmd->data) == 1234)
+                if (CMD_TO_INT(cmd_data) == 1234)
                     armVehicle(500);
                 break;
             case DEARM_VEHICLE:
-                if (*(int*)(&cmd->data) == 1234)
+                if (CMD_TO_INT(cmd_data) == 1234)
                     dearmVehicle();
                 break;
             case FOLLOW_PATH:
                 amData.command = PM_FOLLOW_PATH;
-                amData.followPath = *(char*)(&cmd->data);
+                amData.followPath = *cmd_data;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
@@ -717,57 +723,59 @@ void readDatalink(void){
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SHOW_SCALED_PWM:
-                if ((*(char*)(&cmd->data)) == 1){
+                if (*cmd_data == 1){
                     show_scaled_pwm = 1;
                 } else{
                     show_scaled_pwm = 0;
                 }
                 break;
             case REMOVE_LIMITS:
-                limitSetpoint = (*(bool*)(&cmd->data));
+                limitSetpoint = *(bool*)cmd_data;
             case NEW_WAYPOINT:
-                amData.waypoint = *(WaypointWrapper*)(&cmd->data);
+                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
                 amData.command = PM_NEW_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case INSERT_WAYPOINT:
-                amData.waypoint = *(WaypointWrapper*)(&cmd->data);
+                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
                 amData.command = PM_INSERT_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case UPDATE_WAYPOINT:
-                amData.waypoint = *(WaypointWrapper*)(&cmd->data);
+                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
                 amData.command = PM_UPDATE_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_RETURN_HOME_COORDINATES:
-                amData.waypoint = *(WaypointWrapper*)(&cmd->data);
+                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
                 amData.command = PM_SET_RETURN_HOME_COORDINATES;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case TARE_IMU:
-                adjustVNOrientationMatrix((float*)(&cmd->data));
+                adjustVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd_data));
                 break;
             case SET_IMU:
-                setVNOrientationMatrix((float*)(&cmd->data));
+                setVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd_data));
                 break;
             case SET_KDVALUES:
-                setKValues(KD,(float*)(&cmd->data));
+                setKValues(KD, CMD_TO_FLOAT_ARRAY(cmd_data));
                 break;
             case SET_KPVALUES:
-                setKValues(KP,(float*)(&cmd->data));
+                setKValues(KP, CMD_TO_FLOAT_ARRAY(cmd_data));
                 break;
             case SET_KIVALUES:
-                setKValues(KI,(float*)(&cmd->data));
+                setKValues(KI, CMD_TO_FLOAT_ARRAY(cmd_data));
                 break;
             case SET_GAINS:
             {
-                char* channel = (char*) (&cmd->data);
-                setGains(*channel,((float*)(&cmd->data)) + 1);
+                //note we're using the unaligned version specifically since the first value is the channel type
+                //this makes our original structure word aligned
+                char channel = *cmd->data;
+                setGains(channel, CMD_TO_FLOAT_ARRAY(cmd->data + 1));
                 break;
             }
             default:

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -19,6 +19,7 @@
 #include "../Common/Interfaces/SPI.h"
 #include "Network/Datalink.h"
 #include "ProgramStatus.h"
+#include "Drivers/Radio.h"
 #include <string.h>
 
 int input_RC_Flap; // Flaps need to finish being refactored.
@@ -685,6 +686,7 @@ void readDatalink(void){
                 break;
             case SEND_HEARTBEAT:
                 heartbeatTimer = getTime();
+                queueRadioStatusPacket();
                 break;
             case KILL_PLANE:
                 if (*(int*)(&cmd->data) == 1234)
@@ -875,6 +877,11 @@ bool writeDatalink(p_priority packet){
             statusData->data.p3_block.autonomousLevel = controlLevel;
             statusData->data.p3_block.startupErrorCodes = getStartupErrorCodes();
             statusData->data.p3_block.startupSettings = DEBUG + (VEHICLE_TYPE << 1); //TODO: put this in the startuperrorCode file
+            statusData->data.p3_block.ul_rssi = getRadioRSSI();
+            statusData->data.p3_block.ul_receive_errors = getRadioReceiveErrors();
+            statusData->data.p3_block.dl_transmission_errors = getRadioTransmissionErrors();
+            statusData->data.p3_block.uhf_link_quality = 45;
+            statusData->data.p3_block.uhf_rssi = 25;
             break;
 
         default:

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -516,11 +516,6 @@ uint8_t getControlValue(CtrlType type) {
 
 void readDatalink(void){
     struct DatalinkCommand* cmd = popDatalinkCommand();
-    uint8_t cmd_data[88];
-    
-    //this step is necessary for correct parsing of data, as we can't cast
-    //unaligned data to multi-byte values.
-    memcpy(cmd_data, cmd->data, cmd->data_length);
     
     //TODO: Add rudimentary input validation
     if ( cmd ) {
@@ -539,49 +534,49 @@ void readDatalink(void){
 #endif
                 break;
             case SET_PITCH_KD_GAIN:
-                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd_data));
+                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ROLL_KD_GAIN:
-                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd_data));
+                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_YAW_KD_GAIN:
-                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd_data));
+                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_PITCH_KP_GAIN:
-                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd_data));
+                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ROLL_KP_GAIN:
-                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd_data));
+                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_YAW_KP_GAIN:
-                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd_data));
+                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_PITCH_KI_GAIN:
-                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd_data));
+                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ROLL_KI_GAIN:
-                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd_data));
+                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_YAW_KI_GAIN:
-                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd_data));
+                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_HEADING_KD_GAIN:
-                setGain(HEADING, KD, CMD_TO_FLOAT(cmd_data));
+                setGain(HEADING, KD, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_HEADING_KP_GAIN:
-                setGain(HEADING, KP, CMD_TO_FLOAT(cmd_data));
+                setGain(HEADING, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_HEADING_KI_GAIN:
-                setGain(HEADING, KI, CMD_TO_FLOAT(cmd_data));
+                setGain(HEADING, KI, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ALTITUDE_KD_GAIN:
-                setGain(ALTITUDE, KD, CMD_TO_FLOAT(cmd_data));
+                setGain(ALTITUDE, KD, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ALTITUDE_KP_GAIN:
-                setGain(ALTITUDE, KP, CMD_TO_FLOAT(cmd_data));
+                setGain(ALTITUDE, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ALTITUDE_KI_GAIN:
-                setGain(ALTITUDE, KI, CMD_TO_FLOAT(cmd_data));
+                setGain(ALTITUDE, KI, CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_THROTTLE_KD_GAIN:
                 //setGain(THROTTLE, KD, *(float*)(&cmd->data));
@@ -594,89 +589,89 @@ void readDatalink(void){
                 break;
 
             case SET_PATH_GAIN:
-                amData.pathGain = CMD_TO_FLOAT(cmd_data);
+                amData.pathGain = CMD_TO_FLOAT(cmd->data);
                 amData.command = PM_SET_PATH_GAIN;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_ORBIT_GAIN:
-                amData.orbitGain = CMD_TO_FLOAT(cmd_data);
+                amData.orbitGain = CMD_TO_FLOAT(cmd->data);
                 amData.command = PM_SET_ORBIT_GAIN;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SHOW_GAIN:
-                displayGain = *cmd_data;
+                displayGain = *cmd->data;
                 break;
             case SET_PITCH_RATE:
-                input_GS_PitchRate = CMD_TO_INT(cmd_data);
+                input_GS_PitchRate = CMD_TO_INT(cmd->data);
                 break;
             case SET_ROLL_RATE:
-                input_GS_RollRate = CMD_TO_INT(cmd_data);
+                input_GS_RollRate = CMD_TO_INT(cmd->data);
                 break;
             case SET_YAW_RATE:
-                input_GS_YawRate = CMD_TO_INT(cmd_data);
+                input_GS_YawRate = CMD_TO_INT(cmd->data);
                 break;
             case SET_PITCH_ANGLE:
-                input_GS_Pitch = CMD_TO_INT(cmd_data);
+                input_GS_Pitch = CMD_TO_INT(cmd->data);
                 break;
             case SET_ROLL_ANGLE:
-                input_GS_Roll = CMD_TO_INT(cmd_data);
+                input_GS_Roll = CMD_TO_INT(cmd->data);
                 break;
             case SET_YAW_ANGLE:
 //                sp_YawAngle = *(int*)(&cmd->data);
                 break;
             case SET_ALTITUDE:
-                input_GS_Altitude = CMD_TO_INT(cmd_data);
+                input_GS_Altitude = CMD_TO_INT(cmd->data);
                 break;
             case SET_HEADING:
-                input_GS_Heading = CMD_TO_INT(cmd_data);
+                input_GS_Heading = CMD_TO_INT(cmd->data);
                 break;
             case SET_THROTTLE:
-                input_GS_Throttle = CMD_TO_INT(cmd_data);
+                input_GS_Throttle = CMD_TO_INT(cmd->data);
                 break;
             case SET_FLAP:
-                input_GS_Flap = CMD_TO_INT(cmd_data);//(int)(((long int)(*(int*)(&cmd->data))) * MAX_PWM * 2 / 100) - MAX_PWM;
+                input_GS_Flap = CMD_TO_INT(cmd->data);//(int)(((long int)(*(int*)(&cmd->data))) * MAX_PWM * 2 / 100) - MAX_PWM;
                 break;
             case SET_AUTONOMOUS_LEVEL:
-                controlLevel = CMD_TO_INT(cmd_data);
+                controlLevel = CMD_TO_INT(cmd->data);
                 forceGainUpdate();
                 break;
             case SET_ANGULAR_WALK_VARIANCE:
-                setAngularWalkVariance(CMD_TO_FLOAT(cmd_data));
+                setAngularWalkVariance(CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_GYRO_VARIANCE:
-                setGyroVariance(CMD_TO_FLOAT(cmd_data));
+                setGyroVariance(CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_MAGNETIC_VARIANCE:
-                setMagneticVariance(CMD_TO_FLOAT(cmd_data));
+                setMagneticVariance(CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_ACCEL_VARIANCE:
-                setAccelVariance(CMD_TO_FLOAT(cmd_data));
+                setAccelVariance(CMD_TO_FLOAT(cmd->data));
                 break;
             case SET_SCALE_FACTOR:
-                scaleFactor = CMD_TO_FLOAT(cmd_data);
+                scaleFactor = CMD_TO_FLOAT(cmd->data);
                 break;
             case CALIBRATE_ALTIMETER:
-                amData.calibrationHeight = CMD_TO_FLOAT(cmd_data);
+                amData.calibrationHeight = CMD_TO_FLOAT(cmd->data);
                 amData.command = PM_CALIBRATE_ALTIMETER;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case CLEAR_WAYPOINTS:
-                amData.waypoint.id = *cmd_data; //Dummy Data
+                amData.waypoint.id = *cmd->data; //Dummy Data
                 amData.command = PM_CLEAR_WAYPOINTS;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case REMOVE_WAYPOINT:
-                amData.waypoint.id = *cmd_data;
+                amData.waypoint.id = *cmd->data;
                 amData.command = PM_REMOVE_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_TARGET_WAYPOINT:
-                amData.waypoint.id = *cmd_data;
+                amData.waypoint.id = *cmd->data;
                 amData.command = PM_SET_TARGET_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
@@ -696,24 +691,24 @@ void readDatalink(void){
                 queueRadioStatusPacket();
                 break;
             case KILL_PLANE:
-                if (CMD_TO_INT(cmd_data) == 1234)
+                if (CMD_TO_INT(cmd->data) == 1234)
                     killPlane(TRUE);
                 break;
             case UNKILL_PLANE:
-                if (CMD_TO_INT(cmd_data) == 1234)
+                if (CMD_TO_INT(cmd->data) == 1234)
                     killPlane(FALSE);
                 break;
             case ARM_VEHICLE:
-                if (CMD_TO_INT(cmd_data) == 1234)
+                if (CMD_TO_INT(cmd->data) == 1234)
                     armVehicle(500);
                 break;
             case DEARM_VEHICLE:
-                if (CMD_TO_INT(cmd_data) == 1234)
+                if (CMD_TO_INT(cmd->data) == 1234)
                     dearmVehicle();
                 break;
             case FOLLOW_PATH:
                 amData.command = PM_FOLLOW_PATH;
-                amData.followPath = *cmd_data;
+                amData.followPath = *cmd->data;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
@@ -723,59 +718,59 @@ void readDatalink(void){
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SHOW_SCALED_PWM:
-                if (*cmd_data == 1){
+                if (*cmd->data == 1){
                     show_scaled_pwm = 1;
                 } else{
                     show_scaled_pwm = 0;
                 }
                 break;
             case REMOVE_LIMITS:
-                limitSetpoint = *(bool*)cmd_data;
+                limitSetpoint = *(bool*)cmd->data;
             case NEW_WAYPOINT:
-                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
+                amData.waypoint = CMD_TO_TYPE(cmd->data, WaypointWrapper);
                 amData.command = PM_NEW_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case INSERT_WAYPOINT:
-                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
+                amData.waypoint = CMD_TO_TYPE(cmd->data, WaypointWrapper);
                 amData.command = PM_INSERT_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case UPDATE_WAYPOINT:
-                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
+                amData.waypoint = CMD_TO_TYPE(cmd->data, WaypointWrapper);
                 amData.command = PM_UPDATE_WAYPOINT;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case SET_RETURN_HOME_COORDINATES:
-                amData.waypoint = CMD_TO_TYPE(cmd_data, WaypointWrapper);
+                amData.waypoint = CMD_TO_TYPE(cmd->data, WaypointWrapper);
                 amData.command = PM_SET_RETURN_HOME_COORDINATES;
                 amData.checkbyteDMA = generateAMDataDMACheckbyte();
                 amData.checksum = generateAMDataChecksum(&amData);
                 break;
             case TARE_IMU:
-                adjustVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd_data));
+                adjustVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_IMU:
-                setVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd_data));
+                setVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_KDVALUES:
-                setKValues(KD, CMD_TO_FLOAT_ARRAY(cmd_data));
+                setKValues(KD, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_KPVALUES:
-                setKValues(KP, CMD_TO_FLOAT_ARRAY(cmd_data));
+                setKValues(KP, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_KIVALUES:
-                setKValues(KI, CMD_TO_FLOAT_ARRAY(cmd_data));
+                setKValues(KI, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_GAINS:
             {
-                //note we're using the unaligned version specifically since the first value is the channel type
-                //this makes our original structure word aligned
-                char channel = *cmd->data;
-                setGains(channel, CMD_TO_FLOAT_ARRAY(cmd->data + 1));
+                char channel = cmd->data[0];
+                //We're making the rest of the data word aligned here, which is required for casting it to floats
+                memcpy(cmd->data, cmd->data + 1, cmd->data_length - 1);
+                setGains(channel, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             }
             default:

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -20,6 +20,7 @@
 #include "Network/Datalink.h"
 #include "ProgramStatus.h"
 #include "Drivers/Radio.h"
+#include "Peripherals/UHF.h"
 #include <string.h>
 
 int input_RC_Flap; // Flaps need to finish being refactored.
@@ -880,8 +881,8 @@ bool writeDatalink(p_priority packet){
             statusData->data.p3_block.ul_rssi = getRadioRSSI();
             statusData->data.p3_block.ul_receive_errors = getRadioReceiveErrors();
             statusData->data.p3_block.dl_transmission_errors = getRadioTransmissionErrors();
-            statusData->data.p3_block.uhf_link_quality = 45;
-            statusData->data.p3_block.uhf_rssi = 25;
+            statusData->data.p3_block.uhf_link_quality = getUHFLinkQuality(getTime());
+            statusData->data.p3_block.uhf_rssi = getUHFRSSI(getTime());
             break;
 
         default:

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -773,124 +773,120 @@ void readDatalink(void){
             default:
                 break;
         }
-        freeDatalinkCommand( cmd );
+       // freeDatalinkCommand( cmd );
     }
 }
 
 bool writeDatalink(p_priority packet){
-    TelemetryBlock* statusData = createTelemetryBlock(packet);
-
-    //If Malloc fails, then quit...wait until there is memory available
-    if (!statusData){return 0;}
+    static TelemetryBlock statusData;
 
     int* input;
     int* output; //Pointers used for RC channel inputs and outputs
-
+    statusData.type = packet;
+    
     switch(packet){
         case PRIORITY0:
-            statusData->data.p1_block.lat = getLatitude();
-            statusData->data.p1_block.lon = getLongitude();
-            statusData->data.p1_block.sysTime = getTime();
-            statusData->data.p1_block.UTC = gps_Time;
-            statusData->data.p1_block.pitch = getPitch();
-            statusData->data.p1_block.roll = getRoll();
-            statusData->data.p1_block.yaw = getYaw();
-            statusData->data.p1_block.pitchRate = getPitchRate();
-            statusData->data.p1_block.rollRate = getRollRate();
-            statusData->data.p1_block.yawRate = getYawRate();
-            statusData->data.p1_block.airspeed = airspeed;
-            statusData->data.p1_block.alt = getAltitude();
-            statusData->data.p1_block.gSpeed = gps_GroundSpeed;
-            statusData->data.p1_block.heading = getHeading();
-            statusData->data.p1_block.rollRateSetpoint = getRollRateSetpoint();
-            statusData->data.p1_block.rollSetpoint = getRollAngleSetpoint();
-            statusData->data.p1_block.pitchRateSetpoint = getPitchRateSetpoint();
-            statusData->data.p1_block.pitchSetpoint = getPitchAngleSetpoint();
-            statusData->data.p1_block.throttleSetpoint = getThrottleSetpoint();
+            statusData.data.p1_block.lat = getLatitude();
+            statusData.data.p1_block.lon = getLongitude();
+            statusData.data.p1_block.sysTime = getTime();
+            statusData.data.p1_block.UTC = gps_Time;
+            statusData.data.p1_block.pitch = getPitch();
+            statusData.data.p1_block.roll = getRoll();
+            statusData.data.p1_block.yaw = getYaw();
+            statusData.data.p1_block.pitchRate = getPitchRate();
+            statusData.data.p1_block.rollRate = getRollRate();
+            statusData.data.p1_block.yawRate = getYawRate();
+            statusData.data.p1_block.airspeed = airspeed;
+            statusData.data.p1_block.alt = getAltitude();
+            statusData.data.p1_block.gSpeed = gps_GroundSpeed;
+            statusData.data.p1_block.heading = getHeading();
+            statusData.data.p1_block.rollRateSetpoint = getRollRateSetpoint();
+            statusData.data.p1_block.rollSetpoint = getRollAngleSetpoint();
+            statusData.data.p1_block.pitchRateSetpoint = getPitchRateSetpoint();
+            statusData.data.p1_block.pitchSetpoint = getPitchAngleSetpoint();
+            statusData.data.p1_block.throttleSetpoint = getThrottleSetpoint();
             break;
         case PRIORITY1:
-            statusData->data.p2_block.rollKD = getGain(ROLL_RATE,KD);
-            statusData->data.p2_block.rollKP = getGain(ROLL_RATE,KP);
-            statusData->data.p2_block.pitchKD = getGain(PITCH_RATE,KD);
-            statusData->data.p2_block.pitchKP = getGain(PITCH_RATE,KP);
-            statusData->data.p2_block.yawKD = getGain(YAW_RATE,KD);
-            statusData->data.p2_block.yawKP = getGain(YAW_RATE,KP);
-            statusData->data.p2_block.lastCommandsSent[0] = lastCommandSentCode[lastCommandCounter];
-            statusData->data.p2_block.lastCommandsSent[1] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 1))%COMMAND_HISTORY_SIZE];
-            statusData->data.p2_block.lastCommandsSent[2] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 2))%COMMAND_HISTORY_SIZE];
-            statusData->data.p2_block.lastCommandsSent[3] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 3))%COMMAND_HISTORY_SIZE];
-            statusData->data.p2_block.batteryLevel1 = 50;//batteryLevel1;
-            statusData->data.p2_block.batteryLevel2 = 50;//batteryLevel2;
+            statusData.data.p2_block.rollKD = getGain(ROLL_RATE,KD);
+            statusData.data.p2_block.rollKP = getGain(ROLL_RATE,KP);
+            statusData.data.p2_block.pitchKD = getGain(PITCH_RATE,KD);
+            statusData.data.p2_block.pitchKP = getGain(PITCH_RATE,KP);
+            statusData.data.p2_block.yawKD = getGain(YAW_RATE,KD);
+            statusData.data.p2_block.yawKP = getGain(YAW_RATE,KP);
+            statusData.data.p2_block.lastCommandsSent[0] = lastCommandSentCode[lastCommandCounter];
+            statusData.data.p2_block.lastCommandsSent[1] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 1))%COMMAND_HISTORY_SIZE];
+            statusData.data.p2_block.lastCommandsSent[2] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 2))%COMMAND_HISTORY_SIZE];
+            statusData.data.p2_block.lastCommandsSent[3] = lastCommandSentCode[(lastCommandCounter + (COMMAND_HISTORY_SIZE - 3))%COMMAND_HISTORY_SIZE];
+            statusData.data.p2_block.batteryLevel1 = 50;//batteryLevel1;
+            statusData.data.p2_block.batteryLevel2 = 50;//batteryLevel2;
 //            debug("SW3");
             if (show_scaled_pwm){
                 input = getPWMArray(getTime());
             } else {
                 input = (int*)getICValues(getTime());
             }
-            statusData->data.p2_block.ch1In = input[0];
-            statusData->data.p2_block.ch2In = input[1];
-            statusData->data.p2_block.ch3In = input[2];
-            statusData->data.p2_block.ch4In = input[3];
-            statusData->data.p2_block.ch5In = input[4];
-            statusData->data.p2_block.ch6In = input[5];
-            statusData->data.p2_block.ch7In = input[6];
-            statusData->data.p2_block.ch8In = input[7];
+            statusData.data.p2_block.ch1In = input[0];
+            statusData.data.p2_block.ch2In = input[1];
+            statusData.data.p2_block.ch3In = input[2];
+            statusData.data.p2_block.ch4In = input[3];
+            statusData.data.p2_block.ch5In = input[4];
+            statusData.data.p2_block.ch6In = input[5];
+            statusData.data.p2_block.ch7In = input[6];
+            statusData.data.p2_block.ch8In = input[7];
             output = getPWMOutputs();
-            statusData->data.p2_block.ch1Out = output[0];
-            statusData->data.p2_block.ch2Out = output[1];
-            statusData->data.p2_block.ch3Out = output[2];
-            statusData->data.p2_block.ch4Out = output[3];
-            statusData->data.p2_block.ch5Out = output[4];
-            statusData->data.p2_block.ch6Out = output[5];
-            statusData->data.p2_block.ch7Out = output[6];
-            statusData->data.p2_block.ch8Out = output[7];
+            statusData.data.p2_block.ch1Out = output[0];
+            statusData.data.p2_block.ch2Out = output[1];
+            statusData.data.p2_block.ch3Out = output[2];
+            statusData.data.p2_block.ch4Out = output[3];
+            statusData.data.p2_block.ch5Out = output[4];
+            statusData.data.p2_block.ch6Out = output[5];
+            statusData.data.p2_block.ch7Out = output[6];
+            statusData.data.p2_block.ch8Out = output[7];
 //            debug("SW4");
-            statusData->data.p2_block.yawRateSetpoint = getYawRateSetpoint();
-            statusData->data.p2_block.headingSetpoint = getHeadingSetpoint();
-            statusData->data.p2_block.altitudeSetpoint = getAltitudeSetpoint();
-            statusData->data.p2_block.flapSetpoint = 0;
-            statusData->data.p2_block.wirelessConnection = ((input[5] < 180) << 1) + (input[7] > 0);//+ RSSI;
-            statusData->data.p2_block.autopilotActive = getProgramStatus();
-            statusData->data.p2_block.gpsStatus = gps_Satellites + (gps_PositionFix << 4);
-            statusData->data.p2_block.pathChecksum = waypointChecksum;
-            statusData->data.p2_block.numWaypoints = waypointCount;
-            statusData->data.p2_block.waypointIndex = waypointIndex;
-            statusData->data.p2_block.pathFollowing = pathFollowing; //True or false
+            statusData.data.p2_block.yawRateSetpoint = getYawRateSetpoint();
+            statusData.data.p2_block.headingSetpoint = getHeadingSetpoint();
+            statusData.data.p2_block.altitudeSetpoint = getAltitudeSetpoint();
+            statusData.data.p2_block.flapSetpoint = 0;
+            statusData.data.p2_block.wirelessConnection = ((input[5] < 180) << 1) + (input[7] > 0);//+ RSSI;
+            statusData.data.p2_block.autopilotActive = getProgramStatus();
+            statusData.data.p2_block.gpsStatus = gps_Satellites + (gps_PositionFix << 4);
+            statusData.data.p2_block.pathChecksum = waypointChecksum;
+            statusData.data.p2_block.numWaypoints = waypointCount;
+            statusData.data.p2_block.waypointIndex = waypointIndex;
+            statusData.data.p2_block.pathFollowing = pathFollowing; //True or false
             break;
         case PRIORITY2:
-            statusData->data.p3_block.rollKI = getGain(ROLL_RATE,KI);
-            statusData->data.p3_block.pitchKI = getGain(PITCH_RATE,KI);
-            statusData->data.p3_block.yawKI = getGain(YAW_RATE, KI);
-            statusData->data.p3_block.headingKD = getGain(HEADING, KD);
-            statusData->data.p3_block.headingKP = getGain(HEADING, KP);
-            statusData->data.p3_block.headingKI = getGain(HEADING, KI);
-            statusData->data.p3_block.altitudeKD = getGain(ALTITUDE, KD);
-            statusData->data.p3_block.altitudeKP = getGain(ALTITUDE, KP);
-            statusData->data.p3_block.altitudeKI = getGain(ALTITUDE, KI);
-            statusData->data.p3_block.throttleKD = 0;//getGain(THROTTLE, KD);
-            statusData->data.p3_block.throttleKP = 0;//getGain(THROTTLE, KP);
-            statusData->data.p3_block.throttleKI = 0;//getGain(THROTTLE, KI);
-            statusData->data.p3_block.flapKD = 0;//getGain(FLAP, KD);
-            statusData->data.p3_block.flapKP = 0;//getGain(FLAP, KP);
-            statusData->data.p3_block.flapKI = 0;//getGain(FLAP, KI);
-            statusData->data.p3_block.pathGain = pmPathGain;
-            statusData->data.p3_block.orbitGain = pmOrbitGain;
-            statusData->data.p3_block.autonomousLevel = controlLevel;
-            statusData->data.p3_block.startupErrorCodes = getStartupErrorCodes();
-            statusData->data.p3_block.startupSettings = DEBUG + (VEHICLE_TYPE << 1); //TODO: put this in the startuperrorCode file
-            statusData->data.p3_block.ul_rssi = getRadioRSSI();
-            statusData->data.p3_block.ul_receive_errors = getRadioReceiveErrors();
-            statusData->data.p3_block.dl_transmission_errors = getRadioTransmissionErrors();
-            statusData->data.p3_block.uhf_link_quality = getUHFLinkQuality(getTime());
-            statusData->data.p3_block.uhf_rssi = getUHFRSSI(getTime());
+            statusData.data.p3_block.rollKI = getGain(ROLL_RATE,KI);
+            statusData.data.p3_block.pitchKI = getGain(PITCH_RATE,KI);
+            statusData.data.p3_block.yawKI = getGain(YAW_RATE, KI);
+            statusData.data.p3_block.headingKD = getGain(HEADING, KD);
+            statusData.data.p3_block.headingKP = getGain(HEADING, KP);
+            statusData.data.p3_block.headingKI = getGain(HEADING, KI);
+            statusData.data.p3_block.altitudeKD = getGain(ALTITUDE, KD);
+            statusData.data.p3_block.altitudeKP = getGain(ALTITUDE, KP);
+            statusData.data.p3_block.altitudeKI = getGain(ALTITUDE, KI);
+            statusData.data.p3_block.throttleKD = 0;//getGain(THROTTLE, KD);
+            statusData.data.p3_block.throttleKP = 0;//getGain(THROTTLE, KP);
+            statusData.data.p3_block.throttleKI = 0;//getGain(THROTTLE, KI);
+            statusData.data.p3_block.flapKD = 0;//getGain(FLAP, KD);
+            statusData.data.p3_block.flapKP = 0;//getGain(FLAP, KP);
+            statusData.data.p3_block.flapKI = 0;//getGain(FLAP, KI);
+            statusData.data.p3_block.pathGain = pmPathGain;
+            statusData.data.p3_block.orbitGain = pmOrbitGain;
+            statusData.data.p3_block.autonomousLevel = controlLevel;
+            statusData.data.p3_block.startupErrorCodes = getStartupErrorCodes();
+            statusData.data.p3_block.startupSettings = DEBUG + (VEHICLE_TYPE << 1); //TODO: put this in the startuperrorCode file
+            statusData.data.p3_block.ul_rssi = getRadioRSSI();
+            statusData.data.p3_block.ul_receive_errors = getRadioReceiveErrors();
+            statusData.data.p3_block.dl_transmission_errors = getRadioTransmissionErrors();
+            statusData.data.p3_block.uhf_link_quality = getUHFLinkQuality(getTime());
+            statusData.data.p3_block.uhf_rssi = getUHFRSSI(getTime());
             break;
 
         default:
             break;
     }
-    bool status = queueTelemetryBlock(statusData);
-    free(statusData);
-    return status;
+    return queueTelemetryBlock(&statusData);
 }
 
 void checkUHFStatus(){

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -773,7 +773,7 @@ void readDatalink(void){
             default:
                 break;
         }
-       // freeDatalinkCommand( cmd );
+       freeDatalinkCommand( cmd );
     }
 }
 

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -83,6 +83,16 @@
 #define UPDATE_WAYPOINT 136
 #define SET_GAINS 137
 
+/**
+ * Converts command data into the specified type. Saves on typing. Make sure the data is byte aligned before
+ * calling this or you'll get an OPCODE reset. ie. you cant cast a 3 byte array
+ * into a 2 byte int if the starting index is 1
+ */
+#define CMD_TO_INT(data) (*((int*)data))
+#define CMD_TO_FLOAT(data) (*((float*)data))
+#define CMD_TO_FLOAT_ARRAY(data) ((float*)data)
+#define CMD_TO_TYPE(data, type) (*((type*)data))
+
 //Multipart Command Structs
 
 #endif	/* COMMANDS_H */

--- a/Autopilot/AttitudeManager/Network/Datalink.c
+++ b/Autopilot/AttitudeManager/Network/Datalink.c
@@ -42,7 +42,12 @@ void parseDatalinkBuffer(void) {
         
         command->data_length = length - 1; //data length doesnt acount the cmd id
         command->cmd = received[0];
-        command->data = received + 1; //dont include the cmd id in the data
+        
+        command->data = received;
+        
+        //don't include the command id in the data part of the command. This is required so
+        //that the data that we later parse is word aligned, which is required for casting
+        memcpy(command->data, command->data + 1, command->data_length);
         command->next = NULL;
         
         //append the command to our queue
@@ -63,7 +68,7 @@ DatalinkCommand* popDatalinkCommand(){
 }
 
 void freeDatalinkCommand(DatalinkCommand* to_destroy){
-    free(to_destroy->data - 1); //since data represents the actual data array not including the cmd id
+    free(to_destroy->data);
     free(to_destroy);
 }
 

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -99,6 +99,8 @@ struct priority3_block { //Low Frequency - On update...
     int autonomousLevel;
     unsigned int startupErrorCodes; //2 bytes
     int startupSettings;
+    uint16_t dl_transmission_errors, ul_receive_errors;
+    uint8_t ul_rssi, uhf_rssi, uhf_link_quality;
 };
 
 typedef union {

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -14,16 +14,16 @@
 #include <stdbool.h>
 
 /** Time in miliseconds for how often a P0(high priority) packet gets sent down. Default=300 **/
-#define P0_SEND_FREQUENCY 200 
+#define P0_SEND_FREQUENCY 250 
 
 /** Time in miliseconds for how often a P1(medium priority) packet gets sent down. Default=1000 **/
-#define P1_SEND_FREQUENCY 800
+#define P1_SEND_FREQUENCY 1000
 
 /** Time in miliseconds for how often a P2(low priority) packet gets sent down. Default=20000 **/
 #define P2_SEND_FREQUENCY 5000
 
 /** Time in miliseconds for how often to check for new messages from the uplink. Default=100 **/
-#define UPLINK_CHECK_FREQUENCY 75
+#define UPLINK_CHECK_FREQUENCY 500
 
 // TODO: Put these headers in the new kill mode implementation
 #define HEARTBEAT_TIMEOUT 10000 //In Milliseconds

--- a/Autopilot/AttitudeManager/PWM.h
+++ b/Autopilot/AttitudeManager/PWM.h
@@ -36,12 +36,13 @@
 #define HALF_PWM_RANGE (MAX_PWM - MIN_PWM)/2
 
 /**
- * Maximum and minimum limits received from the controller. These should be calibrated,
- * and the scaling from these values to the MAX and MIN PWM values will depend on these.
- * Note that these will be used as the default/initial values, however the actual scaling values
- * can be set by the ground station
+ * Number of timer2 ticks that represents ~2ms, or the max pwm value
  */
 #define UPPER_PWM 1250
+
+/**
+ * Number of timer2 ticks that represents ~1ms, or lowest pwm value
+ */
 #define LOWER_PWM 625
 
 /**

--- a/Autopilot/AttitudeManager/Peripherals/UHF.c
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.c
@@ -8,7 +8,7 @@
 #include "UHF.h"
 
 uint8_t getUHFRSSI(uint32_t sys_time){
-    if ((getPWMInputStatus() & UHF_RSSI_CHANNEL) == 1){
+    if ((getPWMInputStatus() & (1 << UHF_RSSI_CHANNEL)) != 0){
         return 0;
     }
     uint16_t unscaled = getICValues(sys_time)[UHF_RSSI_CHANNEL - 1];
@@ -22,7 +22,7 @@ uint8_t getUHFRSSI(uint32_t sys_time){
 }
 
 uint8_t getUHFLinkQuality(uint32_t sys_time){
-    if ((getPWMInputStatus() & UHF_LINK_QUALITY_CHANNEL) == 1){
+    if ((getPWMInputStatus() & (1 << UHF_LINK_QUALITY_CHANNEL)) != 0){
         return 0;
     }
     uint16_t unscaled = getICValues(sys_time)[UHF_LINK_QUALITY_CHANNEL - 1];

--- a/Autopilot/AttitudeManager/Peripherals/UHF.c
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.c
@@ -1,0 +1,30 @@
+/* 
+ * @file UHF.h
+ * @author Serj Babayan
+ * @created March 26, 2017, 9:00 PM
+ */
+#include "../InputCapture.h"
+#include "../PWM.h"
+#include "UHF.h"
+
+uint8_t getUHFRSSI(uint32_t sys_time){
+    uint16_t unscaled = getICValues(sys_time)[UHF_RSSI_CHANNEL - 1];
+    int16_t scaled = (((unscaled - LOWER_PWM)*100)/(UPPER_PWM - LOWER_PWM));
+    if (scaled > 100){
+        return 100;
+    } else if (scaled < 0){
+        return 0;
+    }
+    return (uint8_t)scaled;
+}
+
+uint8_t getUHFLinkQuality(uint32_t sys_time){
+    uint16_t unscaled = getICValues(sys_time)[UHF_LINK_QUALITY_CHANNEL - 1];
+    int16_t scaled = (((unscaled - LOWER_PWM)*100)/(UPPER_PWM - LOWER_PWM));
+    if (scaled > 100){
+        return 100;
+    } else if (scaled < 0){
+        return 0;
+    }
+    return (uint8_t)scaled;
+}

--- a/Autopilot/AttitudeManager/Peripherals/UHF.c
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.c
@@ -8,7 +8,7 @@
 #include "UHF.h"
 
 uint8_t getUHFRSSI(uint32_t sys_time){
-    if (getPWMInputStatus() & UHF_RSSI_CHANNEL == 1){
+    if ((getPWMInputStatus() & UHF_RSSI_CHANNEL) == 1){
         return 0;
     }
     uint16_t unscaled = getICValues(sys_time)[UHF_RSSI_CHANNEL - 1];
@@ -22,7 +22,7 @@ uint8_t getUHFRSSI(uint32_t sys_time){
 }
 
 uint8_t getUHFLinkQuality(uint32_t sys_time){
-    if (getPWMInputStatus() & UHF_LINK_QUALITY_CHANNEL == 1){
+    if ((getPWMInputStatus() & UHF_LINK_QUALITY_CHANNEL) == 1){
         return 0;
     }
     uint16_t unscaled = getICValues(sys_time)[UHF_LINK_QUALITY_CHANNEL - 1];

--- a/Autopilot/AttitudeManager/Peripherals/UHF.c
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.c
@@ -8,6 +8,9 @@
 #include "UHF.h"
 
 uint8_t getUHFRSSI(uint32_t sys_time){
+    if (getPWMInputStatus() & UHF_RSSI_CHANNEL == 1){
+        return 0;
+    }
     uint16_t unscaled = getICValues(sys_time)[UHF_RSSI_CHANNEL - 1];
     int16_t scaled = (((unscaled - LOWER_PWM)*100)/(UPPER_PWM - LOWER_PWM));
     if (scaled > 100){
@@ -19,6 +22,9 @@ uint8_t getUHFRSSI(uint32_t sys_time){
 }
 
 uint8_t getUHFLinkQuality(uint32_t sys_time){
+    if (getPWMInputStatus() & UHF_LINK_QUALITY_CHANNEL == 1){
+        return 0;
+    }
     uint16_t unscaled = getICValues(sys_time)[UHF_LINK_QUALITY_CHANNEL - 1];
     int16_t scaled = (((unscaled - LOWER_PWM)*100)/(UPPER_PWM - LOWER_PWM));
     if (scaled > 100){

--- a/Autopilot/AttitudeManager/Peripherals/UHF.h
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.h
@@ -1,0 +1,45 @@
+/* 
+ * @file UHF.h
+ * @author Serj Babayan
+ * @created March 26, 2017, 9:00 PM
+ * UHF peripheral file for retrieving uhf connection statistics such as RSSI
+ * and signal quality. Parses the appropriate PWM channels inputs and converts
+ * them to percentages for sending down the downlink
+ */
+
+#ifndef UHF_H
+#define	UHF_H
+
+#include <stdint.h>
+
+#define UHF_RSSI_CHANNEL 6
+
+#define UHF_LINK_QUALITY_CHANNEL 7
+
+/**
+ * Note that we're not going to be using
+ * @param sys_time
+ * @return 
+ */
+#define UHF_RSSI_MAX_PWM 1210
+#define UHF_RSSI_MIN_PWM 625
+#define UHF_LINK_QUALITY_MAX_PWM 1170
+#define UHF_LINK_QUALITY_MIN_PWM 625
+
+/**
+ * @param sys_time Current system time in ms
+ * @return A percentage value from 0-100 of what the relative signal strength
+ * of the uplink uhf connection is
+ */
+uint8_t getUHFRSSI(uint32_t sys_time);
+
+/**
+ * @param sys_time Current system time in ms
+ * @return A percentage value from 0-100 representing the signal quality. Different
+ * radios represent this differently. This may be a percentage of the frames dropped
+ * out of the last 15 frames in the case of the orange rx, or something else.
+ */
+uint8_t getUHFLinkQuality(uint32_t sys_time);
+
+#endif
+

--- a/Autopilot/AttitudeManager/Peripherals/UHF.h
+++ b/Autopilot/AttitudeManager/Peripherals/UHF.h
@@ -13,23 +13,14 @@
 #include <stdint.h>
 
 #define UHF_RSSI_CHANNEL 6
-
 #define UHF_LINK_QUALITY_CHANNEL 7
-
-/**
- * Note that we're not going to be using
- * @param sys_time
- * @return 
- */
-#define UHF_RSSI_MAX_PWM 1210
-#define UHF_RSSI_MIN_PWM 625
-#define UHF_LINK_QUALITY_MAX_PWM 1170
-#define UHF_LINK_QUALITY_MIN_PWM 625
 
 /**
  * @param sys_time Current system time in ms
  * @return A percentage value from 0-100 of what the relative signal strength
  * of the uplink uhf connection is
+ * 
+ * If the channel has disconnected will return a 0
  */
 uint8_t getUHFRSSI(uint32_t sys_time);
 
@@ -38,6 +29,8 @@ uint8_t getUHFRSSI(uint32_t sys_time);
  * @return A percentage value from 0-100 representing the signal quality. Different
  * radios represent this differently. This may be a percentage of the frames dropped
  * out of the last 15 frames in the case of the orange rx, or something else.
+ * 
+ * If the channel has disconnected will return a 0
  */
 uint8_t getUHFLinkQuality(uint32_t sys_time);
 

--- a/Autopilot/AttitudeManager/nbproject/configurations.xml
+++ b/Autopilot/AttitudeManager/nbproject/configurations.xml
@@ -31,6 +31,9 @@
         <itemPath>Network/Datalink.h</itemPath>
         <itemPath>Network/Commands.h</itemPath>
       </logicalFolder>
+      <logicalFolder name="f2" displayName="Peripherals" projectFiles="true">
+        <itemPath>Peripherals/UHF.h</itemPath>
+      </logicalFolder>
       <logicalFolder name="f4" displayName="PWM Management" projectFiles="true">
         <itemPath>OutputCompare.h</itemPath>
         <itemPath>InputCapture.h</itemPath>
@@ -88,6 +91,9 @@
       <logicalFolder name="f3" displayName="Network" projectFiles="true">
         <itemPath>Network/Datalink.c</itemPath>
       </logicalFolder>
+      <logicalFolder name="f2" displayName="Peripherals" projectFiles="true">
+        <itemPath>Peripherals/UHF.c</itemPath>
+      </logicalFolder>
       <logicalFolder name="f4" displayName="PWM Management" projectFiles="true">
         <itemPath>InputCapture.c</itemPath>
         <itemPath>OutputCompare.c</itemPath>
@@ -139,8 +145,8 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.31</languageToolchainVersion>
-        <platform>2</platform>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <platform>3</platform>
       </toolsSet>
       <compileType>
         <linkerTool>
@@ -154,8 +160,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>

--- a/Autopilot/Path Manager/nbproject/configurations.xml
+++ b/Autopilot/Path Manager/nbproject/configurations.xml
@@ -78,7 +78,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.31</languageToolchainVersion>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
         <platform>3</platform>
       </toolsSet>
       <compileType>
@@ -93,8 +93,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>

--- a/Autopilot/Relay/nbproject/configurations.xml
+++ b/Autopilot/Relay/nbproject/configurations.xml
@@ -30,7 +30,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.30</languageToolchainVersion>
+        <languageToolchainVersion>1.26</languageToolchainVersion>
         <platform>3</platform>
       </toolsSet>
       <compileType>
@@ -45,8 +45,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>
@@ -214,7 +212,7 @@
         <property key="programoptions.usehighvoltageonmclr" value="false"/>
         <property key="programoptions.uselvpprogramming" value="false"/>
         <property key="voltagevalue" value="3.25"/>
-      </ICD3PlatformTool>      
+      </ICD3PlatformTool>
     </conf>
   </confs>
 </configurationDescriptor>


### PR DESCRIPTION
**Changes**
- Used my powers to fix the master branch tree to not include like 40 unessary commits after the revert
- Added UHF module for interpreting the rssi and link quality channel inputs, and sending the data down the downlink
- Sending down xbee rssi, transmission errors, and received error count down the downlink. Refreshing values everytime a heartbeat is received
- Not allocating the Telemetry block dynamically in the writeDatalink function. Instead doing it statically for performance reasons
- Fixed parsing of multi-byte uplink packets. The issue was caused due to having improper byte alignment. For example, the arm command contains 3 bytes, the cmd id, and 2 bytes that are the password. Dereferencing the second entry in the array will give you an opcode reset, since the chip doesnt like to dereference things that aren't word aligned (need to be a multiple of 2). Fixed by copying everything in the command data after the command id to a new, word aligned array so that casts would work
- Still need to do further testing and maybe make the code cleaner but should work for now

Data Relay PR: https://github.com/UWARG/data-relay-station/pull/37