### PR TITLE
Pruned old commands, new gain commands, new downlink format

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -463,6 +463,16 @@ bool showGains(){
     return show_gains;
 }
 
+/**
+ * @param channel
+ * @param gains Order in KP, KI, KD
+ */
+static void setGains(ControlChannel channel, float* gains){
+    setGain(channel, KP, gains[0]);
+    setGain(channel, KI, gains[1]);
+    setGain(channel, KD, gains[2]);    
+}
+
 void readDatalink(void){
     struct DatalinkCommand* cmd = popDatalinkCommand();
    
@@ -481,15 +491,6 @@ void readDatalink(void){
 #if DEBUG
                 debug( (char*) cmd->data);
 #endif
-                break;
-            case SET_HEADING_GAIN:
-                setGain(HEADING, KP, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ALTITUDE_GAIN:
-                setGain(ALTITUDE, KP, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_GROUND_SPEED_GAIN:
-                setGain(GSPEED, KP, CMD_TO_FLOAT(cmd->data));
                 break;
             case SHOW_GAINS:
                 show_gains = true;
@@ -646,29 +647,28 @@ void readDatalink(void){
                 setVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;    
             case SET_ROLL_RATE_GAINS:
-                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
-                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
+                setGains(ROLL_RATE, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_PITCH_RATE_GAINS:
-                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
-                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
+                setGains(PITCH_RATE, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_YAW_RATE_GAINS:
-                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
-                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
+                setGains(YAW_RATE, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_ROLL_ANGLE_GAINS:
-                setGain(ROLL_ANGLE, KP, CMD_TO_FLOAT(cmd->data));
-                setGain(ROLL_ANGLE, KD, CMD_TO_FLOAT(cmd->data + 4));
-                setGain(ROLL_ANGLE, KI, CMD_TO_FLOAT(cmd->data + 8));
+                setGains(ROLL_ANGLE, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             case SET_PITCH_ANGLE_GAINS:
-                setGain(PITCH_ANGLE, KP, CMD_TO_FLOAT(cmd->data));
-                setGain(PITCH_ANGLE, KD, CMD_TO_FLOAT(cmd->data + 4));
-                setGain(PITCH_ANGLE, KI, CMD_TO_FLOAT(cmd->data + 8));
+                setGains(PITCH_ANGLE, CMD_TO_FLOAT_ARRAY(cmd->data));
+                break;
+            case SET_HEADING_GAINS:
+                setGains(HEADING, CMD_TO_FLOAT_ARRAY(cmd->data));
+                break;
+            case SET_ALTITUDE_GAINS:
+                setGains(ALTITUDE, CMD_TO_FLOAT_ARRAY(cmd->data));
+                break;
+            case SET_GROUND_SPEED_GAINS:
+                setGains(GSPEED, CMD_TO_FLOAT_ARRAY(cmd->data));
                 break;
             default:
                 break;

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -754,8 +754,11 @@ bool writeDatalink(PacketType packet){
             statusData.data.gain_block.pitch_angle_ki = getGain(PITCH_ANGLE, KI);
             
             statusData.data.gain_block.heading_kp = getGain(HEADING, KP);
+            statusData.data.gain_block.heading_ki = getGain(HEADING, KI);
             statusData.data.gain_block.altitude_kp = getGain(ALTITUDE, KP);
+            statusData.data.gain_block.altitude_ki = getGain(ALTITUDE, KI);
             statusData.data.gain_block.ground_speed_kp = getGain(GSPEED, KP);
+            statusData.data.gain_block.ground_speed_ki = getGain(GSPEED, KI);
             statusData.data.gain_block.path_kp = pmPathGain;
             statusData.data.gain_block.orbit_kp = pmOrbitGain;
             break;

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -730,6 +730,7 @@ bool writeDatalink(PacketType packet){
        
             statusData.data.status_block.program_state = getProgramStatus(); //TODO: modify this
             statusData.data.status_block.waypoint_index = waypointIndex;
+            statusData.data.status_block.waypoint_count = 0; //TODO: change this later
             break;
         case PACKET_TYPE_GAINS:
             statusData.data.gain_block.roll_rate_kp = getGain(ROLL_RATE, KP);

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -421,20 +421,6 @@ int getHeadingInput(char source){
         return 0;
 }
 
-void setKValues(int type,float* values){
-    int i = 0;
-    for(; i<CONTROL_CHANNELS; i++){
-       setGain(i, type, values[i]);
-    }
-}
-
-void setGains(int channel, float* values){
-    // values are found at index 1 to 3 in the data array
-    setGain(channel,KP,values[0]);
-    setGain(channel,KI,values[1]);
-    setGain(channel,KD,values[2]);
-}
-
 void imuCommunication(){
     /*****************************************************************************
      *****************************************************************************
@@ -485,61 +471,15 @@ void readDatalink(void){
                 debug( (char*) cmd->data);
 #endif
                 break;
-            case SET_PITCH_KD_GAIN:
-                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ROLL_KD_GAIN:
-                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_YAW_KD_GAIN:
-                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_PITCH_KP_GAIN:
-                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ROLL_KP_GAIN:
-                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_YAW_KP_GAIN:
-                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_PITCH_KI_GAIN:
-                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ROLL_KI_GAIN:
-                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_YAW_KI_GAIN:
-                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_HEADING_KD_GAIN:
-                setGain(HEADING, KD, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_HEADING_KP_GAIN:
+            case SET_HEADING_GAIN:
                 setGain(HEADING, KP, CMD_TO_FLOAT(cmd->data));
                 break;
-            case SET_HEADING_KI_GAIN:
-                setGain(HEADING, KI, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ALTITUDE_KD_GAIN:
-                setGain(ALTITUDE, KD, CMD_TO_FLOAT(cmd->data));
-                break;
-            case SET_ALTITUDE_KP_GAIN:
+            case SET_ALTITUDE_GAIN:
                 setGain(ALTITUDE, KP, CMD_TO_FLOAT(cmd->data));
                 break;
-            case SET_ALTITUDE_KI_GAIN:
-                setGain(ALTITUDE, KI, CMD_TO_FLOAT(cmd->data));
+            case SET_GROUND_SPEED_GAIN:
+                setGain(GSPEED, KP, CMD_TO_FLOAT(cmd->data));
                 break;
-            case SET_THROTTLE_KD_GAIN:
-                //setGain(THROTTLE, KD, *(float*)(&cmd->data));
-                break;
-            case SET_THROTTLE_KP_GAIN:
-                //setGain(THROTTLE, KP, *(float*)(&cmd->data));
-                break;
-            case SET_THROTTLE_KI_GAIN:
-                //setGain(THROTTLE, KI, *(float*)(&cmd->data));
-                break;
-
             case SET_PATH_GAIN:
                 interchip_send_buffer.am_data.pathGain = CMD_TO_FLOAT(cmd->data);
                 interchip_send_buffer.am_data.command = PM_SET_PATH_GAIN;
@@ -549,9 +489,6 @@ void readDatalink(void){
                 interchip_send_buffer.am_data.orbitGain = CMD_TO_FLOAT(cmd->data);
                 interchip_send_buffer.am_data.command = PM_SET_ORBIT_GAIN;
                 sendInterchipData();
-                break;
-            case SHOW_GAIN:
-                displayGain = *cmd->data;
                 break;
             case SET_PITCH_RATE:
                 input_GS_PitchRate = CMD_TO_INT(cmd->data);
@@ -693,24 +630,32 @@ void readDatalink(void){
                 break;
             case SET_IMU:
                 setVNOrientationMatrix(CMD_TO_FLOAT_ARRAY(cmd->data));
+                break;    
+            case SET_ROLL_RATE_GAINS:
+                setGain(ROLL_RATE, KP, CMD_TO_FLOAT(cmd->data));
+                setGain(ROLL_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
+                setGain(ROLL_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
                 break;
-            case SET_KDVALUES:
-                setKValues(KD, CMD_TO_FLOAT_ARRAY(cmd->data));
+            case SET_PITCH_RATE_GAINS:
+                setGain(PITCH_RATE, KP, CMD_TO_FLOAT(cmd->data));
+                setGain(PITCH_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
+                setGain(PITCH_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
                 break;
-            case SET_KPVALUES:
-                setKValues(KP, CMD_TO_FLOAT_ARRAY(cmd->data));
+            case SET_YAW_RATE_GAINS:
+                setGain(YAW_RATE, KP, CMD_TO_FLOAT(cmd->data));
+                setGain(YAW_RATE, KD, CMD_TO_FLOAT(cmd->data + 4));
+                setGain(YAW_RATE, KI, CMD_TO_FLOAT(cmd->data + 8));
                 break;
-            case SET_KIVALUES:
-                setKValues(KI, CMD_TO_FLOAT_ARRAY(cmd->data));
+            case SET_ROLL_ANGLE_GAINS:
+                setGain(ROLL_ANGLE, KP, CMD_TO_FLOAT(cmd->data));
+                setGain(ROLL_ANGLE, KD, CMD_TO_FLOAT(cmd->data + 4));
+                setGain(ROLL_ANGLE, KI, CMD_TO_FLOAT(cmd->data + 8));
                 break;
-            case SET_GAINS:
-            {
-                char channel = cmd->data[0];
-                //We're making the rest of the data word aligned here, which is required for casting it to floats
-                memcpy(cmd->data, cmd->data + 1, cmd->data_length - 1);
-                setGains(channel, CMD_TO_FLOAT_ARRAY(cmd->data));
+            case SET_PITCH_ANGLE_GAINS:
+                setGain(PITCH_ANGLE, KP, CMD_TO_FLOAT(cmd->data));
+                setGain(PITCH_ANGLE, KD, CMD_TO_FLOAT(cmd->data + 4));
+                setGain(PITCH_ANGLE, KI, CMD_TO_FLOAT(cmd->data + 8));
                 break;
-            }
             default:
                 break;
         }

--- a/Autopilot/AttitudeManager/AttitudeManager.h
+++ b/Autopilot/AttitudeManager/AttitudeManager.h
@@ -116,6 +116,11 @@ int getFlapInput(char source);
 
 void imuCommunication();
 
+/**
+ * Whether the ground station operator has requested gains to be sent down
+ */
+bool showGains(void);
+
 int coordinatedTurn(float pitchRate, int rollAngle);
 
 uint8_t getControlValue(CtrlType type);

--- a/Autopilot/AttitudeManager/AttitudeManager.h
+++ b/Autopilot/AttitudeManager/AttitudeManager.h
@@ -149,7 +149,7 @@ void readDatalink(void);
  * Output:  An error code indicating if the data was added to the queue successfully.
  *
  *****************************************************************************/
-bool writeDatalink(p_priority packet);
+bool writeDatalink(PacketType packet);
 
 void checkHeartbeat();
 void checkGPS();

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -11,10 +11,7 @@
 #define DEBUG_TEST 0
 
 typedef const enum {
-    SET_HEADING_GAIN = 1,
-    SET_ALTITUDE_GAIN = 2,
-    SET_GROUND_SPEED_GAIN = 3,
-    SHOW_GAINS = 4,
+    SHOW_GAINS = 1,
             
     //unused 15
             
@@ -71,6 +68,9 @@ typedef const enum {
     SET_YAW_RATE_GAINS = 139,
     SET_ROLL_ANGLE_GAINS = 140,
     SET_PITCH_ANGLE_GAINS = 141,
+    SET_HEADING_GAINS = 142,
+    SET_ALTITUDE_GAINS = 143,
+    SET_GROUND_SPEED_GAINS = 144
 } CommandType;
 
 

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -79,9 +79,9 @@ typedef const enum {
  * calling this or you'll get an OPCODE reset. ie. you cant cast a 3 byte array
  * into a 2 byte int if the starting index is 1
  */
-#define CMD_TO_INT(data) (*((int*)data))
-#define CMD_TO_FLOAT(data) (*((float*)data))
-#define CMD_TO_FLOAT_ARRAY(data) ((float*)data)
-#define CMD_TO_TYPE(data, type) (*((type*)data))
+#define CMD_TO_INT(data) (*((int*)(data)))
+#define CMD_TO_FLOAT(data) (*((float*)(data)))
+#define CMD_TO_FLOAT_ARRAY(data) ((float*)(data))
+#define CMD_TO_TYPE(data, type) (*((type*)(data)))
 
 #endif	/* COMMANDS_H */

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -14,6 +14,7 @@ typedef const enum {
     SET_HEADING_GAIN = 1,
     SET_ALTITUDE_GAIN = 2,
     SET_GROUND_SPEED_GAIN = 3,
+    SHOW_GAINS = 4,
             
     //unused 15
             

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -9,79 +9,69 @@
 #define	COMMANDS_H
 
 #define DEBUG_TEST 0
-#define SET_PITCH_KD_GAIN 1
-#define SET_ROLL_KD_GAIN 2
-#define SET_YAW_KD_GAIN 3
-#define SET_PITCH_KP_GAIN 4
-#define SET_ROLL_KP_GAIN 5
-#define SET_YAW_KP_GAIN 6
-#define SET_PITCH_KI_GAIN 7
-#define SET_ROLL_KI_GAIN 8
-#define SET_YAW_KI_GAIN 9
-#define SET_HEADING_KD_GAIN 10
-#define SET_HEADING_KP_GAIN 11
-#define SET_HEADING_KI_GAIN 12
-#define SET_ALTITUDE_KD_GAIN 13
-#define SET_ALTITUDE_KP_GAIN 14
-#define SET_ALTITUDE_KI_GAIN 15
-#define SET_THROTTLE_KD_GAIN 16
-#define SET_THROTTLE_KP_GAIN 17
-#define SET_THROTTLE_KI_GAIN 18
-#define SET_PATH_GAIN 19
-#define SET_ORBIT_GAIN 20
-#define SHOW_GAIN 21
-#define SET_PITCH_RATE 22
-#define SET_ROLL_RATE 23
-#define SET_YAW_RATE 24
-#define SET_PITCH_ANGLE 25
-#define SET_ROLL_ANGLE 26
-#define SET_YAW_ANGLE 27
-#define SET_ALTITUDE 28
-#define SET_HEADING 29
-#define SET_THROTTLE 30
-#define SET_AUTONOMOUS_LEVEL 31
-#define SET_ANGULAR_WALK_VARIANCE 32
-#define SET_GYRO_VARIANCE 33
-#define SET_MAGNETIC_VARIANCE 34
-#define SET_ACCEL_VARIANCE 35
-#define SET_SCALE_FACTOR 36
-#define CALIBRATE_ALTIMETER 37
-#define CLEAR_WAYPOINTS 38
-#define REMOVE_WAYPOINT 39
-#define SET_TARGET_WAYPOINT 40
-#define RETURN_HOME 41
-#define CANCEL_RETURN_HOME 42
-#define SEND_HEARTBEAT 43
-#define UNUSED_44 44
-#define UNUSED_45 45
-#define UNUSED_46 46
-#define KILL_PLANE 47
-#define UNKILL_PLANE 48
-#define UNUSED_49 49
-#define ARM_VEHICLE 50
-#define DEARM_VEHICLE 51
-#define SET_FLAP 52
-#define UNUSED_53 53
-#define UNUSED_54 54
-#define UNUSED_55 55
-#define UNUSED_56 56
-#define UNUSED_57 57
-#define FOLLOW_PATH 58
-#define EXIT_HOLD_ORBIT 59
-#define SHOW_SCALED_PWM 60
-#define REMOVE_LIMITS 61
 
-//Multipart Commands
-#define NEW_WAYPOINT 128
-#define INSERT_WAYPOINT 129
-#define SET_RETURN_HOME_COORDINATES 130
-#define TARE_IMU 131
-#define SET_IMU 132
-#define SET_KDVALUES 133
-#define SET_KPVALUES 134
-#define SET_KIVALUES 135
-#define UPDATE_WAYPOINT 136
-#define SET_GAINS 137
+typedef const enum {
+    SET_HEADING_GAIN = 1,
+    SET_ALTITUDE_GAIN = 2,
+    SET_GROUND_SPEED_GAIN = 3,
+            
+    //unused 15
+            
+    SET_PATH_GAIN = 19,
+    SET_ORBIT_GAIN = 20,
+    SET_PITCH_RATE = 22,
+    SET_ROLL_RATE = 23,
+    SET_YAW_RATE = 24,
+    SET_PITCH_ANGLE = 25,
+    SET_ROLL_ANGLE = 26,
+    SET_YAW_ANGLE = 27,
+    SET_ALTITUDE = 28,
+    SET_HEADING = 29,
+    SET_THROTTLE = 30,
+    SET_AUTONOMOUS_LEVEL = 31,
+    SET_ANGULAR_WALK_VARIANCE = 32,
+    SET_GYRO_VARIANCE = 33,
+    SET_MAGNETIC_VARIANCE = 34,
+    SET_ACCEL_VARIANCE = 35,
+    SET_SCALE_FACTOR = 36,
+    CALIBRATE_ALTIMETER = 37,
+    CLEAR_WAYPOINTS = 38,
+    REMOVE_WAYPOINT = 39,
+    SET_TARGET_WAYPOINT = 40,
+    RETURN_HOME = 41,
+    CANCEL_RETURN_HOME = 42,
+    SEND_HEARTBEAT = 43,
+    
+    //unused 3
+            
+    KILL_PLANE = 47,
+    UNKILL_PLANE = 48,
+    UNUSED_49 = 49,
+    ARM_VEHICLE = 50,
+    DEARM_VEHICLE = 51,
+    SET_FLAP = 52,
+            
+    //unused 6
+            
+    FOLLOW_PATH = 58,
+    EXIT_HOLD_ORBIT = 59,
+    SHOW_SCALED_PWM = 60,
+    REMOVE_LIMITS = 61,
+
+    //Multi-part Commands
+    NEW_WAYPOINT = 128,
+    INSERT_WAYPOINT = 129,
+    SET_RETURN_HOME_COORDINATES = 130,
+    TARE_IMU = 131,
+    SET_IMU = 132,
+    UPDATE_WAYPOINT = 136,
+    SET_ROLL_RATE_GAINS = 137,
+    SET_PITCH_RATE_GAINS = 138,
+    SET_YAW_RATE_GAINS = 139,
+    SET_ROLL_ANGLE_GAINS = 140,
+    SET_PITCH_ANGLE_GAINS = 141,
+} COMMAND_TYPE;
+
 
 /**
  * Converts command data into the specified type. Saves on typing. Make sure the data is byte aligned before
@@ -92,7 +82,5 @@
 #define CMD_TO_FLOAT(data) (*((float*)data))
 #define CMD_TO_FLOAT_ARRAY(data) ((float*)data)
 #define CMD_TO_TYPE(data, type) (*((type*)data))
-
-//Multipart Command Structs
 
 #endif	/* COMMANDS_H */

--- a/Autopilot/AttitudeManager/Network/Commands.h
+++ b/Autopilot/AttitudeManager/Network/Commands.h
@@ -70,7 +70,7 @@ typedef const enum {
     SET_YAW_RATE_GAINS = 139,
     SET_ROLL_ANGLE_GAINS = 140,
     SET_PITCH_ANGLE_GAINS = 141,
-} COMMAND_TYPE;
+} CommandType;
 
 
 /**

--- a/Autopilot/AttitudeManager/Network/Datalink.c
+++ b/Autopilot/AttitudeManager/Network/Datalink.c
@@ -91,7 +91,23 @@ void freeDatalinkCommand(DatalinkCommand* to_destroy){
 }
 
 bool queueTelemetryBlock(TelemetryBlock* telem) {
-    return queueDownlinkPacket((uint8_t*)(telem), sizeof(TelemetryBlock));
+    uint16_t size = 0;
+    switch (telem->type){
+        case PACKET_TYPE_POSITION:
+            size = sizeof(struct packet_type_position_block);
+            break;
+        case PACKET_TYPE_GAINS:
+            size = sizeof(struct packet_type_gain_block);
+            break;
+        case PACKET_TYPE_STATUS:
+            size = sizeof(struct packet_type_status_block);
+            break;
+        case PACKET_TYPE_CHANNELS:
+            size = sizeof(struct packet_type_channels_block);
+            break;
+    }
+    
+    return queueDownlinkPacket((uint8_t*)(telem), size + 2); //2 bytes for the packet type
 }
 
 PacketType getNextPacketType(){

--- a/Autopilot/AttitudeManager/Network/Datalink.c
+++ b/Autopilot/AttitudeManager/Network/Datalink.c
@@ -73,16 +73,6 @@ void freeDatalinkCommand(DatalinkCommand* to_destroy){
     free(to_destroy);
 }
 
-TelemetryBlock* createTelemetryBlock(p_priority packet) {
-    TelemetryBlock* telem = malloc(sizeof(TelemetryBlock));
-    
-    if (telem != NULL){
-        telem->type = (uint8_t)packet;
-    }
- 
-    return telem;
-}
-
 bool queueTelemetryBlock(TelemetryBlock* telem) {
     return queueDownlinkPacket((uint8_t*)(telem), sizeof(TelemetryBlock));
 }

--- a/Autopilot/AttitudeManager/Network/Datalink.c
+++ b/Autopilot/AttitudeManager/Network/Datalink.c
@@ -8,6 +8,7 @@
 
 #include "Datalink.h"
 #include "../Drivers/Radio.h"
+#include "../../Common/Utilities/Logger.h"
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -25,6 +26,14 @@ void initDatalink(void){
     initRadio();
     datalinkCommandQueue.tail = NULL;
     datalinkCommandQueue.head = NULL;
+
+    info("Datalink Initialized");
+    //print out some debug info. Useful for debugging datalink
+    debugInt("Position Block Size", sizeof(struct packet_type_position_block));
+    debugInt("Status Block Size", sizeof(struct packet_type_status_block));
+    debugInt("Gains Block Size", sizeof(struct packet_type_gain_block));
+    debugInt("Channels Block Size", sizeof(struct packet_type_channels_block));
+    debugInt("Telemetry Block Size", sizeof(TelemetryBlock));
 }
 
 void parseDatalinkBuffer(void) {

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -55,33 +55,34 @@ typedef enum _p_priority {
 //62 bytes. High Frequency - Multiple times per second
 struct packet_type_position_block { //
     long double lat, lon;
-    uint32_t sysTime;
-    float UTC;
+    uint32_t sys_time;
+    float gps_time;
     float pitch, roll, yaw;
-    float pitchRate, rollRate, yawRate;
+    float pitch_rate, roll_rate, yaw_rate;
     float airspeed;
-    float alt;
-    float gSpeed;
-    uint16_t heading;
-    
+    float altitude;
+    float ground_speed;
+    int16_t heading;
 };
 
-//36 bytes. Medium frequency. About once every second
+//44 bytes. Medium frequency. About once every second
 struct packet_type_status_block {
-    int16_t rollRateSetpoint, pitchRateSetpoint, yawRateSetpoint; 
-    int16_t rollSetpoint, pitchSetpoint;
-    int16_t headingSetpoint, altitudeSetpoint, throttleSetpoint;
+    int16_t roll_rate_setpoint, pitch_rate_setpoint, yaw_rate_setpoint; 
+    int16_t roll_setpoint, pitch_setpoint;
+    int16_t heading_setpoint, altitude_setpoint, throttle_setpoint;
     
-    int16_t batteryLevel1, batteryLevel2;
-    uint16_t autonomousLevel;
-    uint16_t startupErrorCodes; //2 bytes
-    uint16_t dl_transmission_errors, ul_receive_errors;
-    uint8_t ul_rssi, uhf_rssi, uhf_link_quality;
-    uint8_t pathFollowing;
-    uint8_t waypointIndex;
-    uint8_t gpsStatus;
-    uint8_t numWaypoints;
-    uint8_t autopilotActive;
+    int16_t internal_battery_voltage, external_battery_voltage;
+
+    uint16_t program_state; //state of autopilot. vehicle type, armed, unarmed, kill mode. Heartbeat status
+    uint16_t autonomous_level; //rate, angle control sources, etc
+    uint16_t startup_errors;
+    uint16_t am_interchip_errors, pm_interchip_errors, gps_communication_errors; //error counts for dma communications
+    uint16_t dl_transmission_errors, ul_receive_errors; //xbee specific transmission errors
+    uint16_t peripheral_status; //sensor and radio statuses
+    uint16_t uhf_channel_status; //which channels are connected and disconnected
+    uint8_t ul_rssi, uhf_rssi, uhf_link_quality; //ul_rssi is for telemetry receival rssi
+    
+    uint8_t waypoint_index;
 };
 
 //80 bytes
@@ -100,11 +101,12 @@ struct packet_type_gain_block{
     float orbit_kp;
 };
 
-//32 bytes
+//34 bytes
 struct packet_type_channels_block {
     int16_t ch1_in, ch2_in, ch3_in, ch4_in, ch5_in, ch6_in, ch7_in, ch8_in;
     int16_t ch1_out, ch2_out, ch3_out, ch4_out, ch5_out, ch6_out, ch7_out, ch8_out;
     bool channels_scaled; //whether the following values are scaled, or raw
+    uint8_t padding; //padding byte not necessary but will be added either way due to struct packing
 };
 
 typedef union {
@@ -114,8 +116,8 @@ typedef union {
     struct packet_type_channels_block channels_block;
 } PacketPayload;
 
-typedef struct TelemetryBlock {
-    uint8_t type;
+typedef struct {
+    uint16_t type; // 2 bytes to avoid weird padding issues
     PacketPayload data;
 } TelemetryBlock;
 

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -12,6 +12,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "Commands.h"
 
 /** Time in miliseconds for how often a P0(high priority) packet gets sent down. Default=300 **/
 #define P0_SEND_FREQUENCY 250 

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -48,8 +48,8 @@ typedef enum {
 static const uint8_t DEFAULT_PACKET_ORDER[] = {
     PACKET_TYPE_POSITION,
     PACKET_TYPE_POSITION,
-    PACKET_TYPE_POSITION,
     PACKET_TYPE_STATUS,
+    PACKET_TYPE_POSITION,
     PACKET_TYPE_POSITION,
     PACKET_TYPE_CHANNELS
 };
@@ -105,9 +105,9 @@ struct packet_type_gain_block{
     float roll_angle_kp, roll_angle_kd, roll_angle_ki;
     float pitch_angle_kp, pitch_angle_kd, pitch_angle_ki;
     
-    float heading_kp;
-    float altitude_kp;
-    float ground_speed_kp;
+    float heading_kp, heading_ki;
+    float altitude_kp, altitude_ki;
+    float ground_speed_kp, ground_speed_ki;
     
     float path_kp;
     float orbit_kp;

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -14,14 +14,14 @@
 #include <stdbool.h>
 #include "Commands.h"
 
-/** Time in miliseconds for how often a P0(high priority) packet gets sent down. Default=300 **/
-#define P0_SEND_FREQUENCY 250 
+/** Time in ms of how often a packet containing aircraft positional information will be sent*/
+#define POSITION_SEND_FREQUENCY 250
 
-/** Time in miliseconds for how often a P1(medium priority) packet gets sent down. Default=1000 **/
-#define P1_SEND_FREQUENCY 1000
+/** Time in ms of how often a packet containing autopilot status information will be sent*/
+#define STATUS_SEND_FREQUENCY 1000
 
-/** Time in miliseconds for how often a P2(low priority) packet gets sent down. Default=20000 **/
-#define P2_SEND_FREQUENCY 5000
+/** Time in ms of how often a packet containing channel information will be sent*/
+#define CHANNELS_SEND_FREQUENCY 2000
 
 /** Time in miliseconds for how often to check for new messages from the uplink. Default=100 **/
 #define UPLINK_CHECK_FREQUENCY 500
@@ -36,10 +36,11 @@
 #define UHF_KILL_TIMEOUT 10000
 
 typedef enum _p_priority {
-    PRIORITY0 = 0,
-    PRIORITY1 = 1,
-    PRIORITY2 = 2,
-} p_priority;
+    PACKET_TYPE_POSITION = 0,
+    PACKET_TYPE_STATUS = 1,
+    PACKET_TYPE_GAINS = 2,
+    PACKET_TYPE_CHANNELS = 3
+} PacketType;
 
 
 /* For reference: 
@@ -51,63 +52,66 @@ typedef enum _p_priority {
  long double    : 8 bytes
  */
 
-// 72 bytes
-struct priority1_block { //High Frequency - Multiple times per second
-    long double lat, lon; // Latitude and longitude from gps    // 2x8 Byte
-    long int sysTime; // 4 bytes
-    float UTC; //4 Byte
+//62 bytes. High Frequency - Multiple times per second
+struct packet_type_position_block { //
+    long double lat, lon;
+    uint32_t sysTime;
+    float UTC;
     float pitch, roll, yaw;
     float pitchRate, rollRate, yawRate;
     float airspeed;
-    float alt; //4 Byte
+    float alt;
     float gSpeed;
-    int heading; //2 Byte
-    int rollRateSetpoint, rollSetpoint;
-    int pitchRateSetpoint, pitchSetpoint;
-    int throttleSetpoint;
+    uint16_t heading;
+    
 };
 
-// 88 bytes
-struct priority2_block { //Medium Frequency - Once every second
-    float rollKD, rollKP;
-    float pitchKD, pitchKP;
-    float yawKD, yawKP;
-    float pathChecksum; // 4 bytes
-    int lastCommandsSent[4]; //4*2 bytes
-    int batteryLevel1, batteryLevel2; // 2*2 bytes
-    int ch1In,ch2In,ch3In,ch4In,ch5In,ch6In,ch7In,ch8In;
-    int ch1Out,ch2Out,ch3Out,ch4Out,ch5Out,ch6Out,ch7Out,ch8Out;
-    int cameraStatus;
-    int yawRateSetpoint, headingSetpoint, altitudeSetpoint, flapSetpoint;
-    char wirelessConnection; //1 byte
-    char autopilotActive; //1 byte  
-    char gpsStatus; //1 Byte
-    char numWaypoints; //1 bytes
-    char waypointIndex; //1 byte
-    char pathFollowing; // 1 byte
-};
-
-// 74 bytes
-struct priority3_block { //Low Frequency - On update...
-    float rollKI; //4 Bytes
-    float pitchKI;
-    float yawKI;
-    float headingKD, headingKP, headingKI;
-    float altitudeKD, altitudeKP, altitudeKI;
-    float throttleKD, throttleKP, throttleKI;
-    float flapKD, flapKP, flapKI;
-    float pathGain, orbitGain;
-    int autonomousLevel;
-    unsigned int startupErrorCodes; //2 bytes
-    int startupSettings;
+//36 bytes. Medium frequency. About once every second
+struct packet_type_status_block {
+    int16_t rollRateSetpoint, pitchRateSetpoint, yawRateSetpoint; 
+    int16_t rollSetpoint, pitchSetpoint;
+    int16_t headingSetpoint, altitudeSetpoint, throttleSetpoint;
+    
+    int16_t batteryLevel1, batteryLevel2;
+    uint16_t autonomousLevel;
+    uint16_t startupErrorCodes; //2 bytes
     uint16_t dl_transmission_errors, ul_receive_errors;
     uint8_t ul_rssi, uhf_rssi, uhf_link_quality;
+    uint8_t pathFollowing;
+    uint8_t waypointIndex;
+    uint8_t gpsStatus;
+    uint8_t numWaypoints;
+    uint8_t autopilotActive;
+};
+
+//80 bytes
+struct packet_type_gain_block{
+    float roll_rate_kp, roll_rate_kd, roll_rate_ki;
+    float pitch_rate_kp, pitch_rate_kd, pitch_rate_ki;
+    float yaw_rate_kp, yaw_rate_kd, yaw_rate_ki;
+    float roll_angle_kp, roll_angle_kd, roll_angle_ki;
+    float pitch_angle_kp, pitch_angle_kd, pitch_angle_ki;
+    
+    float heading_kp;
+    float altitude_kp;
+    float ground_speed_kp;
+    
+    float path_kp;
+    float orbit_kp;
+};
+
+//32 bytes
+struct packet_type_channels_block {
+    int16_t ch1_in, ch2_in, ch3_in, ch4_in, ch5_in, ch6_in, ch7_in, ch8_in;
+    int16_t ch1_out, ch2_out, ch3_out, ch4_out, ch5_out, ch6_out, ch7_out, ch8_out;
+    bool channels_scaled; //whether the following values are scaled, or raw
 };
 
 typedef union {
-    struct priority1_block p1_block;
-    struct priority2_block p2_block;
-    struct priority3_block p3_block;
+    struct packet_type_position_block position_block;
+    struct packet_type_status_block status_block;
+    struct packet_type_gain_block gain_block;
+    struct packet_type_channels_block channels_block;
 } PacketPayload;
 
 typedef struct TelemetryBlock {
@@ -155,7 +159,7 @@ void freeDatalinkCommand(DatalinkCommand* to_destroy);
  * @param packet Priority of the packet
  * @return NULL if malloc failed
  */
-TelemetryBlock* createTelemetryBlock(p_priority packet);
+TelemetryBlock* createTelemetryBlock(PacketType packet);
 
 /**
  * Queues a telemetry block to be sent down the data link

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -76,7 +76,7 @@ struct packet_type_position_block { //
     int16_t heading;
 };
 
-//44 bytes. Medium frequency. About once every second
+//46 bytes. Medium frequency. About once every second
 struct packet_type_status_block {
     int16_t roll_rate_setpoint, pitch_rate_setpoint, yaw_rate_setpoint; 
     int16_t roll_setpoint, pitch_setpoint;
@@ -92,8 +92,9 @@ struct packet_type_status_block {
     uint16_t peripheral_status; //sensor and radio statuses
     uint16_t uhf_channel_status; //which channels are connected and disconnected
     uint8_t ul_rssi, uhf_rssi, uhf_link_quality; //ul_rssi is for telemetry receival rssi
-    
+
     uint8_t waypoint_index;
+    uint8_t waypoint_count;
 };
 
 //80 bytes

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -97,7 +97,7 @@ struct packet_type_status_block {
     uint8_t waypoint_count;
 };
 
-//80 bytes
+//92 bytes
 struct packet_type_gain_block{
     float roll_rate_kp, roll_rate_kd, roll_rate_ki;
     float pitch_rate_kp, pitch_rate_kd, pitch_rate_ki;

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -127,7 +127,7 @@ typedef union {
 } PacketPayload;
 
 typedef struct {
-    uint16_t type; // 2 bytes to avoid weird padding issues
+    uint16_t type; // 2 bytes as this is what the data relay expects the size to be
     PacketPayload data;
 } TelemetryBlock;
 

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -117,7 +117,6 @@ struct packet_type_channels_block {
     int16_t ch1_in, ch2_in, ch3_in, ch4_in, ch5_in, ch6_in, ch7_in, ch8_in;
     int16_t ch1_out, ch2_out, ch3_out, ch4_out, ch5_out, ch6_out, ch7_out, ch8_out;
     bool channels_scaled; //whether the following values are scaled, or raw
-    uint8_t padding; //padding byte not necessary but will be added either way due to struct packing
 };
 
 typedef union {

--- a/Autopilot/AttitudeManager/OutputCompare.c
+++ b/Autopilot/AttitudeManager/OutputCompare.c
@@ -7,8 +7,19 @@
 #include "OutputCompare.h"
 #include "InputCapture.h"
 
+static uint16_t oc_values[8];
+
+uint16_t* getOCValues(){
+    return oc_values;
+}
+
 void setOCValue(unsigned int channel, unsigned int duty)
 {
+    if (channel < 0 || channel > 7){ //input validation
+        return;
+    }
+    oc_values[channel] = duty;
+
     switch(channel){
     case 0:
         OC1RS = duty;

--- a/Autopilot/AttitudeManager/OutputCompare.h
+++ b/Autopilot/AttitudeManager/OutputCompare.h
@@ -9,6 +9,8 @@
 #ifndef OUTPUTCAPTURE_H
 #define	OUTPUTCAPTURE_H
 
+#include <stdint.h>
+
 /**
  * Initializes the output compare registers and pins for PWM output. Writes a 1.5 ms
  * duty cycle on the selected channels to start off with
@@ -22,5 +24,12 @@ void initOC(char OC);
  * @param time Time/duty cycle in Timer2 ticks, not ms
  */
 void setOCValue(unsigned int channel, unsigned int duty);
+
+
+/**
+ * Retrieve the set values for the output compare
+ * @return ms output of all the channels in Timer2 ticks. Returned array will be of size 8
+ */
+uint16_t* getOCValues(void);
 
 #endif

--- a/Autopilot/AttitudeManager/StateMachine.c
+++ b/Autopilot/AttitudeManager/StateMachine.c
@@ -19,9 +19,7 @@
 //State Machine Triggers (Mostly Timers)
 static int dmaTimer = 0;
 static int uplinkTimer = 0;
-static int downlinkPositionTimer = 0;
-static int downlinkStatusTimer = 0;
-static int downlinkChannelsTimer = 0;
+static int downlinkTimer = 0;
 static int imuTimer = 0;
 static long int stateMachineTimer = 0;
 static int dTime = 0;
@@ -33,9 +31,7 @@ void StateMachine(char entryLocation){
     dTime = (int)(getTime() - stateMachineTimer);
     stateMachineTimer += dTime;
     uplinkTimer += dTime;
-    downlinkPositionTimer += dTime;
-    downlinkStatusTimer += dTime;
-    downlinkChannelsTimer += dTime;
+    downlinkTimer += dTime;
     imuTimer += dTime;
     dmaTimer += dTime;
 
@@ -82,19 +78,13 @@ void StateMachine(char entryLocation){
         readDatalink();
     }
 
-    if(POSITION_SEND_FREQUENCY <= downlinkPositionTimer){
-        downlinkPositionTimer = 0;
-        writeDatalink(PACKET_TYPE_POSITION);
+    if(downlinkTimer >= DOWNLINK_SEND_INTERVAL){
+        downlinkTimer = 0;
+        writeDatalink(getNextPacketType());
     }
-    else if(STATUS_SEND_FREQUENCY <= downlinkStatusTimer){
-        downlinkStatusTimer = 0;
-        writeDatalink(PACKET_TYPE_STATUS);
-    }
-    else if(CHANNELS_SEND_FREQUENCY <= downlinkChannelsTimer){
-        downlinkChannelsTimer = 0;
-        writeDatalink(PACKET_TYPE_CHANNELS);
-    } else if (areGainsUpdated() || showGains()){
-        writeDatalink(PACKET_TYPE_GAINS);
+
+    if (areGainsUpdated() || showGains()){
+        queuePacketType(PACKET_TYPE_GAINS);
     }
     
     parseDatalinkBuffer(); //read any incoming data from the Xbee and put in buffer

--- a/Autopilot/AttitudeManager/StateMachine.c
+++ b/Autopilot/AttitudeManager/StateMachine.c
@@ -19,9 +19,9 @@
 //State Machine Triggers (Mostly Timers)
 static int dmaTimer = 0;
 static int uplinkTimer = 0;
-static int downlinkP0Timer = 0;
-static int downlinkP1Timer = 0;
-static int downlinkP2Timer = 0;
+static int downlinkPositionTimer = 0;
+static int downlinkStatusTimer = 0;
+static int downlinkChannelsTimer = 0;
 static int imuTimer = 0;
 static long int stateMachineTimer = 0;
 static int dTime = 0;
@@ -33,9 +33,9 @@ void StateMachine(char entryLocation){
     dTime = (int)(getTime() - stateMachineTimer);
     stateMachineTimer += dTime;
     uplinkTimer += dTime;
-    downlinkP0Timer += dTime;
-    downlinkP1Timer += dTime;
-    downlinkP2Timer += dTime;
+    downlinkPositionTimer += dTime;
+    downlinkStatusTimer += dTime;
+    downlinkChannelsTimer += dTime;
     imuTimer += dTime;
     dmaTimer += dTime;
 
@@ -82,28 +82,21 @@ void StateMachine(char entryLocation){
         readDatalink();
     }
 
-    if(P0_SEND_FREQUENCY <= downlinkP0Timer){
-        //debug("P0");
-        //Compile and send data
-        downlinkP0Timer = 0;
-        writeDatalink(PRIORITY0);
+    if(POSITION_SEND_FREQUENCY <= downlinkPositionTimer){
+        downlinkPositionTimer = 0;
+        writeDatalink(PACKET_TYPE_POSITION);
     }
-    else if(P1_SEND_FREQUENCY <= downlinkP1Timer){
-        //debug("P1");
-        //Compile and send data
-        downlinkP1Timer = 0;
-        writeDatalink(PRIORITY1);
+    else if(STATUS_SEND_FREQUENCY <= downlinkStatusTimer){
+        downlinkStatusTimer = 0;
+        writeDatalink(PACKET_TYPE_STATUS);
     }
-    else if(P2_SEND_FREQUENCY <= downlinkP2Timer || areGainsUpdated()){
-        //debug("P2");
-        //Compile and send data
-        downlinkP2Timer = 0;
-        writeDatalink(PRIORITY2);
+    else if(CHANNELS_SEND_FREQUENCY <= downlinkChannelsTimer){
+        downlinkChannelsTimer = 0;
+        writeDatalink(PACKET_TYPE_CHANNELS);
+    } else if (areGainsUpdated()){
+        writeDatalink(PACKET_TYPE_GAINS);
     }
-    else{
-        //Then Sleep
-    }
-    //Loop it back again!
+    
     parseDatalinkBuffer(); //read any incoming data from the Xbee and put in buffer
     sendQueuedDownlinkPacket(); //send any outgoing info
     

--- a/Autopilot/AttitudeManager/StateMachine.c
+++ b/Autopilot/AttitudeManager/StateMachine.c
@@ -93,7 +93,7 @@ void StateMachine(char entryLocation){
     else if(CHANNELS_SEND_FREQUENCY <= downlinkChannelsTimer){
         downlinkChannelsTimer = 0;
         writeDatalink(PACKET_TYPE_CHANNELS);
-    } else if (areGainsUpdated()){
+    } else if (areGainsUpdated() || showGains()){
         writeDatalink(PACKET_TYPE_GAINS);
     }
     

--- a/Autopilot/AttitudeManager/nbproject/configurations.xml
+++ b/Autopilot/AttitudeManager/nbproject/configurations.xml
@@ -165,8 +165,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>

--- a/Autopilot/Common/Interfaces/InterchipDMA.h
+++ b/Autopilot/Common/Interfaces/InterchipDMA.h
@@ -57,6 +57,8 @@ typedef struct { // 60 Bytes
     int sp_Heading; //Degrees
     int batteryLevel1;
     int batteryLevel2;
+    uint16_t interchip_error_count; //how many dma errors the path manager has received from the attitude manager
+    uint16_t gps_communication_error_count; //number of dma errors between gps and path manager, if applicable
     char satellites; //1 Byte
     char positionFix; //0 = No GPS, 1 = GPS fix, 2 = DGSP Fix
     char targetWaypoint;

--- a/Autopilot/Path Manager/PathManager.c
+++ b/Autopilot/Path Manager/PathManager.c
@@ -152,6 +152,7 @@ void pathManagerRuntime(void) {
     
     if (getTimeUs() - interchip_last_send_time >= INTERCHIP_SEND_INTERVAL_US){
         interchip_last_send_time = getTimeUs();
+        interchip_send_buffer.pm_data.interchip_error_count = getInterchipErrorCount();
         sendInterchipData();
     }
 }

--- a/Autopilot/Path Manager/nbproject/configurations.xml
+++ b/Autopilot/Path Manager/nbproject/configurations.xml
@@ -99,8 +99,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>

--- a/Autopilot/Relay/nbproject/configurations.xml
+++ b/Autopilot/Relay/nbproject/configurations.xml
@@ -45,8 +45,6 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
-        <subordinates>
-        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>


### PR DESCRIPTION
**Changes:**
- Added interchip dma errors counts to downlink
- Purged old set gain commands and replaced with new ones
- Removed priority based packet types. Now they are related based on the information they hold (ie. position, status, gains, channels)
- Modified state machine such that now there is a minimum interval of time between when packets get sent, and a queue that determines what packet should be sent. Now that we have 1 timer, this avoids issues when we had a priority 1 timer being a multiple of a priority 2 timer, causing them to send immediately one after the other
- Gains type packet now only sends on request, or if the gains were updated
- Fixed parsing of floats for gains in readDatalink() function
- Renamed lots of variables to match our naming convention
- Added ability to display non-scaled pwm outputs in datalink
- Purged alot of status variables that were being sent down. Replaced with new ones (ie. gps status replaced with peripheral status, etc)..


Corresponding datalink PR:
https://github.com/UWARG/data-relay-station/pull/38