### PR TITLE
Added blinkenlights

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -12,7 +12,6 @@
 #include "InputCapture.h"
 #include "OutputCompare.h"
 #include "PWM.h"
-#include "AttitudeManager.h"
 #include "Network/Commands.h"
 #include "StartupErrorCodes.h"
 #include "main.h"
@@ -23,6 +22,7 @@
 #include "Peripherals/UHF.h"
 #include "../Common/Interfaces/InterchipDMA.h"
 #include "../Common/Clock/Timer.h"
+#include "../Common/Utilities/LED.h"
 #include <string.h>
 
 int input_RC_Flap; // Flaps need to finish being refactored.
@@ -134,6 +134,7 @@ void attitudeInit() {
     //Initialize Timer
     initTimer4();
     
+    initLED(1);
     
     initSPI(IC_DMA_PORT, 0, SPI_MODE1, SPI_BYTE, SPI_SLAVE);
     initInterchip(DMA_CHIP_ID_ATTITUDE_MANAGER);

--- a/Autopilot/AttitudeManager/StateMachine.c
+++ b/Autopilot/AttitudeManager/StateMachine.c
@@ -15,12 +15,14 @@
 #include "Drivers/Radio.h"
 #include "ProgramStatus.h"
 #include "../Common/Clock/Timer.h"
+#include "../Common/Utilities/LED.h"
 
 //State Machine Triggers (Mostly Timers)
 static int dmaTimer = 0;
 static int uplinkTimer = 0;
 static int downlinkTimer = 0;
 static int imuTimer = 0;
+static int ledTimer = 0;
 static long int stateMachineTimer = 0;
 static int dTime = 0;
 
@@ -33,6 +35,7 @@ void StateMachine(char entryLocation){
     uplinkTimer += dTime;
     downlinkTimer += dTime;
     imuTimer += dTime;
+    ledTimer += dTime;
     dmaTimer += dTime;
 
     //Clear Watchdog timer
@@ -85,6 +88,16 @@ void StateMachine(char entryLocation){
 
     if (areGainsUpdated() || showGains()){
         queuePacketType(PACKET_TYPE_GAINS);
+    }
+    
+    // Update status LED
+    if (ledTimer >= LED_BLINK_LONG) {
+        toggleLEDState();
+        if (getProgramStatus() == UNARMED) {
+            ledTimer -= LED_BLINK_LONG;
+        } else if (getProgramStatus() == MAIN_EXECUTION) {
+            ledTimer -= LED_BLINK_SHORT;
+        }
     }
     
     parseDatalinkBuffer(); //read any incoming data from the Xbee and put in buffer

--- a/Autopilot/AttitudeManager/main.h
+++ b/Autopilot/AttitudeManager/main.h
@@ -19,15 +19,6 @@
  */
 #define DEBUG 0
 
-//Defines the usage of this chip. It may be one or multiple of the following roles:
-//  Path Manager - Communicates with the GPS in order to provide a constant
-//                  heading for the aircraft to follow.
-//  Attitude Manager - Communicates with a IMU (kinematics sensor) in order to
-//                     the desires Pitch, Roll, Yaw on the aircraft.
-//TODO References to these should be stripped out, as they are now in seperate code bases - Serge Sept 2016
-#define PATH_MANAGER 0
-#define ATTITUDE_MANAGER !PATH_MANAGER
-
 //Define this for competition, includes higher restrictions for safety
 #define COMP_MODE 0
 

--- a/Autopilot/AttitudeManager/nbproject/configurations.xml
+++ b/Autopilot/AttitudeManager/nbproject/configurations.xml
@@ -47,6 +47,7 @@
         <itemPath>fmath.h</itemPath>
         <itemPath>../Common/Utilities/ByteQueue.h</itemPath>
         <itemPath>../Common/Utilities/Logger.h</itemPath>
+        <itemPath>../Common/Utilities/LED.h</itemPath>
       </logicalFolder>
       <logicalFolder name="f7" displayName="VectorNav" projectFiles="true">
         <itemPath>VN100.h</itemPath>
@@ -109,6 +110,7 @@
         <itemPath>delay.c</itemPath>
         <itemPath>../Common/Utilities/ByteQueue.c</itemPath>
         <itemPath>../Common/Utilities/Logger.c</itemPath>
+        <itemPath>../Common/Utilities/LED.c</itemPath>
       </logicalFolder>
       <logicalFolder name="f6" displayName="VectorNav" projectFiles="true">
         <itemPath>VN100.c</itemPath>
@@ -150,7 +152,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <languageToolchainVersion>1.31</languageToolchainVersion>
         <platform>2</platform>
       </toolsSet>
       <compileType>
@@ -165,6 +167,8 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
+        <subordinates>
+        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>

--- a/Autopilot/Common/Utilities/LED.c
+++ b/Autopilot/Common/Utilities/LED.c
@@ -1,0 +1,49 @@
+#include "LED.h"
+
+#define AM_LED (PORTGbits.RG15)
+#define PM_LED (PORTDbits.RD1)
+
+static int8_t chip_id = -1;
+
+void initLED(bool isAttMan) {
+    if (isAttMan){
+        TRISGbits.TRISG15 = 0; // set RG15 to output (led pin)
+        chip_id = 0;
+    } else {
+        TRISDbits.TRISD1 = 0; // set RD1/OC2 to an output (led pin)
+        
+        T3CONbits.TON = 0; // Disable Timer
+        T3CONbits.TCS = 0; // Select internal instruction cycle clock
+        T3CONbits.TGATE = 0; // Disable Gated Timer mode
+        T3CONbits.TCKPS = 0x02; //1:64 scaler
+        TMR3 = 0x00; // Clear timer register
+        PR3 = 5*625; //set the period (5 ms)
+        IPC2bits.T3IP = 0x01; // Set Timer 3 Interrupt Priority Level - Lowest
+        IFS0bits.T3IF = 0; // Clear Timer 3 Interrupt Flag
+        IEC0bits.T3IE = 0; // Disable Timer 3 interrupt
+        T3CONbits.TON = 1; // Start Timer
+        
+        OC2CONbits.OCM = 0b000; // configure Output Compare module 2
+        OC2RS = 0x00;
+        OC2CONbits.OCTSEL = 1; // use timer 3
+        OC2CONbits.OCM = 0b110;
+        chip_id = 1;
+    }
+}
+
+void setLEDState(bool on) {
+    if (chip_id == 0) AM_LED = on; 
+    else if (chip_id == 1) PM_LED = on;
+}
+
+void toggleLEDState() {
+    if (chip_id == 0) AM_LED ^= 1; 
+    else if (chip_id == 1) PM_LED ^= 1;
+}
+
+// only available for PM chip
+// value: 0-255
+void setLEDBrightness(uint8_t value) {
+    if (chip_id != 1) return;
+    OC2RS = (uint16_t)value * (PR3 / 255);
+}

--- a/Autopilot/Common/Utilities/LED.h
+++ b/Autopilot/Common/Utilities/LED.h
@@ -1,0 +1,18 @@
+#ifndef LED_H
+#define LED_H
+
+#include <p33FJ256GP710A.h>
+#include "../Common.h"
+
+#define LED_BLINK_LONG 1000
+#define LED_BLINK_SHORT 250
+
+
+void initLED(bool isAttMan);
+
+void setLEDState(bool on);
+
+void toggleLEDState();
+
+void setLEDBrightness(uint8_t value);
+#endif

--- a/Autopilot/Path Manager/PathManager.c
+++ b/Autopilot/Path Manager/PathManager.c
@@ -16,6 +16,7 @@
 #include "../Common/Interfaces/SPI.h"
 #include "../Common/Interfaces/InterchipDMA.h"
 #include "../Common/Clock/Timer.h"
+#include "../Common/Utilities/LED.h"
 #include "GPSDMA.h"
 
 #if DEBUG
@@ -54,9 +55,14 @@ char inHold = 0;
 
 static uint64_t interchip_last_send_time = 0;
 
+static uint8_t led_bright = 0;
+static bool going_up = true;
+
 void pathManagerInit(void) {
     initTimer4();
- 
+    
+    initLED(0);
+    
     //Communication with GPS
     init_DMA2();
     initSPI(GPS_SPI_PORT, 0, SPI_MODE1, SPI_WORD, SPI_SLAVE);
@@ -126,6 +132,15 @@ void pathManagerRuntime(void) {
 #endif
     copyGPSData();
 
+    // Update status LED
+    if (led_bright == 0) going_up = true;
+    else if (led_bright == 255) going_up = false;
+    
+    if (going_up) led_bright++;
+    else led_bright--;
+    
+    setLEDBrightness(led_bright);
+    
     if (returnHome){
         interchip_send_buffer.pm_data.targetWaypoint = -1;
     } else {

--- a/Autopilot/Path Manager/nbproject/configurations.xml
+++ b/Autopilot/Path Manager/nbproject/configurations.xml
@@ -17,6 +17,7 @@
       <logicalFolder name="f1" displayName="Utilities" projectFiles="true">
         <itemPath>../Common/Utilities/Logger.h</itemPath>
         <itemPath>../Common/Utilities/ByteQueue.h</itemPath>
+        <itemPath>../Common/Utilities/LED.h</itemPath>
       </logicalFolder>
       <itemPath>Dubins.h</itemPath>
       <itemPath>main.h</itemPath>
@@ -49,6 +50,7 @@
       <logicalFolder name="f2" displayName="Utilities" projectFiles="true">
         <itemPath>../Common/Utilities/ByteQueue.c</itemPath>
         <itemPath>../Common/Utilities/Logger.c</itemPath>
+        <itemPath>../Common/Utilities/LED.c</itemPath>
       </logicalFolder>
       <itemPath>Dubins.c</itemPath>
       <itemPath>main.c</itemPath>
@@ -84,7 +86,7 @@
         <targetPluginBoard></targetPluginBoard>
         <platformTool>ICD3PlatformTool</platformTool>
         <languageToolchain>XC16</languageToolchain>
-        <languageToolchainVersion>1.26</languageToolchainVersion>
+        <languageToolchainVersion>1.31</languageToolchainVersion>
         <platform>3</platform>
       </toolsSet>
       <compileType>
@@ -99,6 +101,8 @@
           <parseOnProdLoad>false</parseOnProdLoad>
           <alternateLoadableFile></alternateLoadableFile>
         </loading>
+        <subordinates>
+        </subordinates>
       </compileType>
       <makeCustomizationType>
         <makeCustomizationPreStepEnabled>false</makeCustomizationPreStepEnabled>


### PR DESCRIPTION
PICpilot now will blink happily when you turn it on.
Even better, the blinking LEDs mean something!
Attitude manager's LED blinks slowly (1/sec) when unarmed, faster (4/sec) when armed.
Path manager's LED is connected to an OC pin, so it's set up to do the classic "heartbeat" pulse.
Both give immediate feedback about the level of operation for each chip, making it obvious if a chip is broken or stalled.