### PR TITLE
Pathfollowing

### DIFF
--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -735,7 +735,6 @@ bool writeDatalink(PacketType packet){
             statusData.data.status_block.waypoint_index = waypointIndex;
             statusData.data.status_block.waypoint_count = waypointCount;
             statusData.data.status_block.path_checksum = waypointChecksum;
-            statusData.data.status_block.following_path = pathFollowing;
             break;
         case PACKET_TYPE_GAINS:
             statusData.data.gain_block.roll_rate_kp = getGain(ROLL_RATE, KP);

--- a/Autopilot/AttitudeManager/AttitudeManager.c
+++ b/Autopilot/AttitudeManager/AttitudeManager.c
@@ -735,6 +735,7 @@ bool writeDatalink(PacketType packet){
             statusData.data.status_block.waypoint_index = waypointIndex;
             statusData.data.status_block.waypoint_count = waypointCount;
             statusData.data.status_block.path_checksum = waypointChecksum;
+            statusData.data.status_block.following_path = pathFollowing;
             break;
         case PACKET_TYPE_GAINS:
             statusData.data.gain_block.roll_rate_kp = getGain(ROLL_RATE, KP);

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -87,7 +87,6 @@ struct packet_type_status_block {
 
     uint8_t waypoint_index;
     uint8_t waypoint_count;
-    char following_path;
 };
 
 //92 bytes

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -87,6 +87,7 @@ struct packet_type_status_block {
 
     uint8_t waypoint_index;
     uint8_t waypoint_count;
+    char following_path;
 };
 
 //92 bytes

--- a/Autopilot/AttitudeManager/Network/Datalink.h
+++ b/Autopilot/AttitudeManager/Network/Datalink.h
@@ -87,7 +87,7 @@ struct packet_type_status_block {
 
     uint8_t waypoint_index;
     uint8_t waypoint_count;
-    char following_path;
+    uint8_t following_path;
 };
 
 //92 bytes


### PR DESCRIPTION
We need to pass following path down to ground station to be able to properly toggle the start/stop following button in groundstation for debugging. This is the picpilot changes to support that.